### PR TITLE
Fix hydration mismatch in version footer

### DIFF
--- a/lib/version.ts
+++ b/lib/version.ts
@@ -3,7 +3,7 @@
 
 export const VERSION = {
   number: '0.2.0',
-  buildTime: process.env.NEXT_PUBLIC_BUILD_TIME || new Date().toISOString(),
+  buildTime: process.env.NEXT_PUBLIC_BUILD_TIME || 'dev',
   gitCommit: process.env.NEXT_PUBLIC_GIT_COMMIT || 'dev',
   environment: process.env.NEXT_PUBLIC_VERCEL_ENV || process.env.NODE_ENV || 'development'
 } as const
@@ -13,15 +13,9 @@ export function getVersionString(): string {
 }
 
 export function getBuildTimeString(): string {
+  if (VERSION.buildTime === 'dev') return 'dev build'
   const date = new Date(VERSION.buildTime)
-  return date.toLocaleString('en-US', {
-    month: 'short',
-    day: 'numeric',
-    year: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit',
-    timeZoneName: 'short'
-  })
+  return date.toISOString().replace('T', ' ').replace(/\.\d+Z$/, ' UTC')
 }
 
 export function getShortCommit(): string {


### PR DESCRIPTION
## Summary
- Replace `new Date().toISOString()` fallback with static `'dev'` string to avoid server/client rendering differences
- Use ISO format instead of locale-dependent `toLocaleString()` for deterministic output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Development builds now consistently display as “dev build.”
  * Build timestamps are presented in a standardized UTC format for improved consistency across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->