### PR TITLE
UI cleanup: nav, badges, branding, and consistency fixes

### DIFF
--- a/app/calculator/AdvancedEstimate.module.css
+++ b/app/calculator/AdvancedEstimate.module.css
@@ -163,7 +163,7 @@
 .calcBtn {
   height: 42px;
   padding: 0 28px;
-  background: var(--red);
+  background: var(--blue);
   color: #fff;
   border: none;
   border-radius: 4px;
@@ -174,7 +174,7 @@
   transition: background 150ms;
   white-space: nowrap;
 }
-.calcBtn:hover { background: #cc0000; }
+.calcBtn:hover { background: #004d99; }
 .calcBtn:disabled {
   background: #ccc;
   cursor: not-allowed;

--- a/app/calculator/AdvancedEstimate.tsx
+++ b/app/calculator/AdvancedEstimate.tsx
@@ -316,7 +316,7 @@ export default function AdvancedEstimate() {
             onClick={handleCalculate}
             disabled={isLoading || !model.includes('/')}
           >
-            {isLoading ? 'Calculating...' : 'Calculate GPU Requirement'}
+            {isLoading ? 'Calculating...' : 'Calculate'}
           </button>
         </div>
       </div>

--- a/app/calculator/AdvancedEstimate.tsx
+++ b/app/calculator/AdvancedEstimate.tsx
@@ -13,13 +13,12 @@ import CheckCircleIcon from '@patternfly/react-icons/dist/esm/icons/check-circle
 import InfoCircleIcon from '@patternfly/react-icons/dist/esm/icons/info-circle-icon';
 
 import styles from './AdvancedEstimate.module.css';
-import { MODEL_CATALOG } from '@/lib/gpu-math/models';
 import { GPU_CATALOG, GPU_OPTIONS_ADV } from '@/lib/gpu-math/gpus';
 import { fetchModelConfig } from '@/lib/huggingface/fetch-config';
 import { useGpuSizer } from '@/contexts/GpuSizerContext';
+import { useAicCatalog } from '@/lib/hooks/useAicCatalog';
 import { GpuChipLoader } from '@/components/GpuChipLoader/GpuChipLoader';
 
-const MODEL_OPTIONS = MODEL_CATALOG.map(m => m.hfId);
 
 // ─── FlipTile (reused from Quick Estimate pattern) ───────────────────────────
 
@@ -125,6 +124,9 @@ function friendlyErrorHint(code: string | null): string {
 // ─── Component ───────────────────────────────────────────────────────────────
 
 export default function AdvancedEstimate() {
+  const { modelOptions: aicModels } = useAicCatalog();
+  const MODEL_OPTIONS = aicModels;
+
   // Input state
   const [model, setModel] = React.useState('Qwen/Qwen3-32B');
   const [gpuSystem, setGpuSystem] = React.useState(
@@ -167,7 +169,7 @@ export default function AdvancedEstimate() {
   React.useEffect(() => {
     const timer = setTimeout(() => {
       if (!model.includes('/')) { setModelStatus('idle'); return; }
-      const inCatalog = MODEL_CATALOG.some(m => m.hfId === model);
+      const inCatalog = MODEL_OPTIONS.includes(model);
       setModelStatus(inCatalog ? 'catalog' : 'fetching');
       fetchModelConfig(model, hfToken).then(r => {
         if (r.success && r.config) {
@@ -178,7 +180,7 @@ export default function AdvancedEstimate() {
       });
     }, 500);
     return () => clearTimeout(timer);
-  }, [model, hfToken]);
+  }, [model, hfToken, MODEL_OPTIONS]);
 
   // Fetch live pricing
   React.useEffect(() => {
@@ -212,7 +214,6 @@ export default function AdvancedEstimate() {
   // Get GPU + model spec from catalog
   const currentGpuOption = GPU_OPTIONS_ADV.find(g => g.systemId === gpuSystem) || GPU_OPTIONS_ADV[0];
   const gpuSpec = GPU_CATALOG.find(g => g.id === currentGpuOption.id);
-  const catalogModel = MODEL_CATALOG.find(m => m.hfId === model);
 
   const handleCalculate = () => {
     startSizing({ model_path: model, system: gpuSystem, isl, osl, ttft, tpot: 30, target_concurrency: 32 });

--- a/app/calculator/AdvancedEstimate.tsx
+++ b/app/calculator/AdvancedEstimate.tsx
@@ -264,6 +264,8 @@ export default function AdvancedEstimate() {
                 onChange={e => setModel(e.target.value)}
                 list="model-options"
                 placeholder="e.g. meta-llama/Llama-3.1-70B-Instruct"
+                spellCheck={false}
+                autoComplete="off"
               />
               <datalist id="model-options">
                 {MODEL_OPTIONS.map(m => <option key={m} value={m} />)}

--- a/app/calculator/AdvancedEstimate.tsx
+++ b/app/calculator/AdvancedEstimate.tsx
@@ -124,7 +124,7 @@ function friendlyErrorHint(code: string | null): string {
 // ─── Component ───────────────────────────────────────────────────────────────
 
 export default function AdvancedEstimate() {
-  const { modelOptions: aicModels } = useAicCatalog();
+  const { modelOptions: aicModels, isLoading: catalogLoading } = useAicCatalog();
   const MODEL_OPTIONS = aicModels;
 
   // Input state
@@ -167,20 +167,23 @@ export default function AdvancedEstimate() {
 
   // Model status check + fetch HF config
   React.useEffect(() => {
+    if (catalogLoading) { setModelStatus('idle'); return; }
     const timer = setTimeout(() => {
       if (!model.includes('/')) { setModelStatus('idle'); return; }
       const inCatalog = MODEL_OPTIONS.includes(model);
       setModelStatus(inCatalog ? 'catalog' : 'fetching');
-      fetchModelConfig(model, hfToken).then(r => {
-        if (r.success && r.config) {
-          setModelStatus(inCatalog ? 'catalog' : 'fetched');
-        } else {
-          if (!inCatalog) setModelStatus('error');
-        }
-      });
+      if (!inCatalog) {
+        fetchModelConfig(model, hfToken).then(r => {
+          if (r.success && r.config) {
+            setModelStatus('fetched');
+          } else {
+            setModelStatus('error');
+          }
+        });
+      }
     }, 500);
     return () => clearTimeout(timer);
-  }, [model, hfToken, MODEL_OPTIONS]);
+  }, [model, hfToken, MODEL_OPTIONS, catalogLoading]);
 
   // Fetch live pricing
   React.useEffect(() => {

--- a/app/kv-cache/KvCacheCalc.tsx
+++ b/app/kv-cache/KvCacheCalc.tsx
@@ -127,7 +127,7 @@ export default function KvCacheCalc() {
       <div className={styles.inputCard}>
         <div className={styles.inputRow}>
           <div className={styles.field}>
-            <label htmlFor="kv-model" className={styles.fieldLabel}>Model</label>
+            <label htmlFor="kv-model" className={styles.fieldLabel}>Model — Hugging Face ID</label>
             <div className={styles.modelInputWrapper}>
               <input
                 type="text"

--- a/app/kv-cache/KvCacheCalc.tsx
+++ b/app/kv-cache/KvCacheCalc.tsx
@@ -19,7 +19,7 @@ const BREAKDOWN_COLORS: Record<string, string> = {
 }
 
 export default function KvCacheCalc() {
-  const { modelOptions: aicModels } = useAicCatalog()
+  const { modelOptions: aicModels, isLoading: catalogLoading } = useAicCatalog()
   const MODEL_OPTIONS = aicModels
 
   const [model, setModel] = React.useState('Qwen/Qwen3-32B')
@@ -140,7 +140,7 @@ export default function KvCacheCalc() {
               </datalist>
               {model && (
                 <span className={`${styles.modelChip} ${catalogMatch ? styles.modelChipCatalog : styles.modelChipCustom}`}>
-                  {catalogMatch ? 'In catalog' : 'Custom model'}
+                  {catalogMatch ? 'In catalog' : catalogLoading ? 'Loading...' : 'Custom model'}
                 </span>
               )}
             </div>

--- a/app/kv-cache/KvCacheCalc.tsx
+++ b/app/kv-cache/KvCacheCalc.tsx
@@ -24,9 +24,11 @@ export default function KvCacheCalc() {
   const MODEL_OPTIONS = aicModels
 
   const [model, setModel] = React.useState('Qwen/Qwen3-32B')
-  const [system, setSystem] = React.useState(GPU_OPTIONS_KV[0]?.systemId ?? '')
+  const [system, setSystem] = React.useState(
+    GPU_OPTIONS_KV.find(g => g.systemId === 'h200_sxm')?.systemId ?? GPU_OPTIONS_KV[0]?.systemId ?? ''
+  )
   const [backend, setBackend] = React.useState('vllm')
-  const [backendVersion, setBackendVersion] = React.useState('')
+  const [backendVersion, setBackendVersion] = React.useState('0.24.0')
   const [maxNumTokens, setMaxNumTokens] = React.useState(8192)
   const [maxBatchSize, setMaxBatchSize] = React.useState(128)
   const [tpSize, setTpSize] = React.useState(1)

--- a/app/kv-cache/KvCacheCalc.tsx
+++ b/app/kv-cache/KvCacheCalc.tsx
@@ -135,6 +135,8 @@ export default function KvCacheCalc() {
                 onChange={e => setModel(e.target.value)}
                 placeholder="Type model name or select from dropdown..."
                 className={styles.modelInput}
+                spellCheck={false}
+                autoComplete="off"
               />
               <datalist id="kv-models">
                 {MODEL_OPTIONS.map(m => <option key={m} value={m} />)}

--- a/app/kv-cache/KvCacheCalc.tsx
+++ b/app/kv-cache/KvCacheCalc.tsx
@@ -1,7 +1,8 @@
 'use client'
 
 import * as React from 'react'
-import { Alert, Spinner } from '@patternfly/react-core'
+import { Alert, Label, Spinner } from '@patternfly/react-core'
+import CheckCircleIcon from '@patternfly/react-icons/dist/esm/icons/check-circle-icon'
 import { GPU_OPTIONS_KV } from '@/lib/gpu-math/gpus'
 import { formatBytes } from '@/lib/utils/format'
 import { useCountUp } from '@/app/quick-estimate/quickEstimateHelpers'
@@ -139,8 +140,14 @@ export default function KvCacheCalc() {
                 {MODEL_OPTIONS.map(m => <option key={m} value={m} />)}
               </datalist>
               {model && (
-                <span className={`${styles.modelChip} ${catalogMatch ? styles.modelChipCatalog : styles.modelChipCustom}`}>
-                  {catalogMatch ? 'In catalog' : catalogLoading ? 'Loading...' : 'Custom model'}
+                <span className={styles.modelChip}>
+                  {catalogMatch ? (
+                    <Label color="green" isCompact icon={<CheckCircleIcon />}>In catalog</Label>
+                  ) : catalogLoading ? (
+                    <Label color="blue" isCompact>Loading...</Label>
+                  ) : (
+                    <Label color="grey" isCompact>Custom model</Label>
+                  )}
                 </span>
               )}
             </div>

--- a/app/kv-cache/KvCacheCalc.tsx
+++ b/app/kv-cache/KvCacheCalc.tsx
@@ -2,14 +2,13 @@
 
 import * as React from 'react'
 import { Alert, Spinner } from '@patternfly/react-core'
-import { MODEL_CATALOG } from '@/lib/gpu-math/models'
 import { GPU_OPTIONS_KV } from '@/lib/gpu-math/gpus'
 import { formatBytes } from '@/lib/utils/format'
 import { useCountUp } from '@/app/quick-estimate/quickEstimateHelpers'
+import { useAicCatalog } from '@/lib/hooks/useAicCatalog'
 import type { KvCacheCalcResult } from '@/lib/api/kv-cache-calc'
 import styles from './KvCacheCalc.module.css'
 
-const MODEL_OPTIONS = MODEL_CATALOG.map(m => m.hfId)
 
 const BREAKDOWN_COLORS: Record<string, string> = {
   kv: '#0066cc',
@@ -20,7 +19,10 @@ const BREAKDOWN_COLORS: Record<string, string> = {
 }
 
 export default function KvCacheCalc() {
-  const [model, setModel] = React.useState(MODEL_CATALOG[0]?.hfId ?? '')
+  const { modelOptions: aicModels } = useAicCatalog()
+  const MODEL_OPTIONS = aicModels
+
+  const [model, setModel] = React.useState('Qwen/Qwen3-32B')
   const [system, setSystem] = React.useState(GPU_OPTIONS_KV[0]?.systemId ?? '')
   const [backend, setBackend] = React.useState('vllm')
   const [backendVersion, setBackendVersion] = React.useState('')
@@ -43,7 +45,7 @@ export default function KvCacheCalc() {
   const [debugStatus, setDebugStatus] = React.useState<number | null>(null)
   const [debugDuration, setDebugDuration] = React.useState<number | null>(null)
 
-  const catalogMatch = MODEL_CATALOG.find(m => m.hfId === model)
+  const catalogMatch = MODEL_OPTIONS.includes(model)
 
   async function handleCalculate() {
     setLoading(true)

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -61,9 +61,12 @@ const redHatMono = Red_Hat_Mono({
 });
 
 export const metadata: Metadata = {
-  title: "GPU Calc — LLM Inference Sizing & Cost Calculator",
+  title: "ConfigIQ — LLM inference sizing and cost calculator",
   description:
     "Estimate GPU requirements, compare costs, and model LLM inference economics across cloud and on-premise deployments.",
+  icons: {
+    icon: "/config-iq-logo.svg",
+  },
 };
 
 export default function RootLayout({

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -76,7 +76,7 @@ export default function HomePage() {
           </div>
           <TextContent>
             <Title headingLevel="h1" size="2xl">
-              GPU Calc
+              ConfigIQ
             </Title>
             <Text component="p">
               LLM inference sizing, GPU comparison, and cost modeling for

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -17,10 +17,18 @@ import {
   CpuIcon,
   CalculatorIcon,
   RouteIcon,
+  BoltIcon,
 } from "@patternfly/react-icons";
 import Link from "next/link";
 
 const tools = [
+  {
+    title: "Quick Estimate",
+    description:
+      "Fast GPU sizing from a model name and workload profile. Results in seconds.",
+    href: "/quick-estimate",
+    icon: <BoltIcon />,
+  },
   {
     title: "KV Cache Calculator",
     description:

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -23,7 +23,7 @@ import Link from "next/link";
 
 const tools = [
   {
-    title: "Quick Estimate",
+    title: "Quick estimate",
     description:
       "Fast GPU sizing from a model name and workload profile. Results in seconds.",
     href: "/quick-estimate",

--- a/app/quick-estimate/QuickEstimate.tsx
+++ b/app/quick-estimate/QuickEstimate.tsx
@@ -949,6 +949,8 @@ export default function QuickEstimate() {
                 placeholder="Type model name or select from dropdown..."
                 aria-label="Model Hugging Face ID"
                 className={styles.modelInput}
+                spellCheck={false}
+                autoComplete="off"
               />
               <datalist id="qe-models">
                 {MODEL_OPTIONS.map((m) => <option key={m} value={m} />)}

--- a/app/quick-estimate/QuickEstimate.tsx
+++ b/app/quick-estimate/QuickEstimate.tsx
@@ -28,7 +28,6 @@ import styles from './QuickEstimate.module.css';
 import { Term, FlipTile, Sparkline, useCountUp } from './quickEstimateHelpers';
 import { ProductTour, type TourStep } from '@/components/ProductTour';
 import { SaveEstimateModal } from './SaveEstimateModal';
-import { MODEL_CATALOG } from '@/lib/gpu-math/models';
 import { GPU_CATALOG, GPU_OPTIONS_QE } from '@/lib/gpu-math/gpus';
 import { fetchModelConfig, type HFModelConfig } from '@/lib/huggingface/fetch-config';
 import { saveEstimate, getSavedEstimateCount } from '@/lib/saved-estimates';
@@ -37,7 +36,6 @@ import { useAicCatalog } from '@/lib/hooks/useAicCatalog';
 import type { InferenceConfigResult } from '@/lib/gpu-math/inference-config';
 import Link from 'next/link';
 
-const STATIC_MODEL_OPTIONS = MODEL_CATALOG.map(m => m.hfId);
 const STATIC_GPU_OPTIONS = GPU_OPTIONS_QE.map(g => g.label);
 
 function mapGpuToCatalogId(uiGpuName: string): string {
@@ -92,10 +90,7 @@ export default function QuickEstimate() {
     () => aicGpus.length > 0 ? aicGpus.map(g => g.label) : STATIC_GPU_OPTIONS,
     [aicGpus],
   );
-  const MODEL_OPTIONS = React.useMemo(
-    () => aicModels.length > 0 ? aicModels : STATIC_MODEL_OPTIONS,
-    [aicModels],
-  );
+  const MODEL_OPTIONS = aicModels;
 
   const [model, setModel] = React.useState('Qwen/Qwen3-32B');
   const [gpu, setGpu] = React.useState('');
@@ -959,14 +954,14 @@ export default function QuickEstimate() {
                 {MODEL_OPTIONS.map((m) => <option key={m} value={m} />)}
               </datalist>
               <div className={styles.autoChipWrapper}>
-                {isFetchingConfig ? (
-                  <Label color="blue">🔄 Fetching from HuggingFace...</Label>
-                ) : MODEL_CATALOG.find(m => m.hfId === model || m.id === model || m.name === model) ? (
-                  <Label color="green" icon={<CheckCircleIcon />}>✓ In catalog</Label>
+                {MODEL_OPTIONS.includes(model) ? (
+                  <Label color="green" icon={<CheckCircleIcon />}>In catalog</Label>
+                ) : isFetchingConfig || catalogLoading ? (
+                  <Label color="blue">🔄 Checking model...</Label>
                 ) : hfConfig ? (
-                  <Label color="cyan" icon={<CheckCircleIcon />}>✓ Fetched from HuggingFace</Label>
+                  <Label color="cyan" icon={<CheckCircleIcon />}>From HuggingFace</Label>
                 ) : testError ? (
-                  <Label color="red" icon={<ExclamationTriangleIcon />}>❌ Not found</Label>
+                  <Label color="red" icon={<ExclamationTriangleIcon />}>Not found</Label>
                 ) : (
                   <Label color="grey">Type to search...</Label>
                 )}

--- a/app/quick-estimate/QuickEstimate.tsx
+++ b/app/quick-estimate/QuickEstimate.tsx
@@ -981,7 +981,7 @@ export default function QuickEstimate() {
 
           {/* Column 2: GPU target */}
           <div className={styles.field}>
-            <label className={styles.fieldLabel} htmlFor="qe-gpu">GPU target</label>
+            <label className={styles.fieldLabel} htmlFor="qe-gpu">GPU system</label>
             <select
               id="qe-gpu"
               value={gpu}

--- a/components/layout/AppShell.tsx
+++ b/components/layout/AppShell.tsx
@@ -145,6 +145,12 @@ export function AppShell({ children }: { children: React.ReactNode }) {
 
             <NavItemWithIcon
               icon={BoltIcon}
+              label="Quick estimate"
+              href="/quick-estimate"
+              isActive={pathname === "/quick-estimate"}
+            />
+            <NavItemWithIcon
+              icon={BoltIcon}
               label="KV cache calculator"
               href="/kv-cache"
               isActive={pathname === "/kv-cache"}

--- a/components/layout/AppShell.tsx
+++ b/components/layout/AppShell.tsx
@@ -17,6 +17,7 @@ import { usePathname } from "next/navigation";
 import {
   HomeIcon,
   BoltIcon,
+  CalculatorIcon,
   SlidersHIcon,
   CubesIcon,
   HistoryIcon,
@@ -150,7 +151,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
               isActive={pathname === "/quick-estimate"}
             />
             <NavItemWithIcon
-              icon={BoltIcon}
+              icon={CalculatorIcon}
               label="KV cache calculator"
               href="/kv-cache"
               isActive={pathname === "/kv-cache"}

--- a/lib/hooks/useAicCatalog.ts
+++ b/lib/hooks/useAicCatalog.ts
@@ -34,37 +34,58 @@ function mapSystem(s: Record<string, unknown>): GpuOption {
   }
 }
 
+// Module-level cache — shared across all components, survives re-renders
+let cachedGpus: GpuOption[] | null = null
+let cachedModels: string[] | null = null
+let fetchPromise: Promise<void> | null = null
+
 export function useAicCatalog(): AicCatalog {
-  const [gpuOptions, setGpuOptions] = useState<GpuOption[]>([])
-  const [modelOptions, setModelOptions] = useState<string[]>([])
-  const [isLoading, setIsLoading] = useState(true)
+  const [gpuOptions, setGpuOptions] = useState<GpuOption[]>(cachedGpus ?? [])
+  const [modelOptions, setModelOptions] = useState<string[]>(cachedModels ?? [])
+  const [isLoading, setIsLoading] = useState(cachedGpus === null)
   const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
+    if (cachedGpus !== null && cachedModels !== null) {
+      setGpuOptions(cachedGpus)
+      setModelOptions(cachedModels)
+      setIsLoading(false)
+      return
+    }
+
     let cancelled = false
     const aicUrl = process.env.NEXT_PUBLIC_AICONFIGURATOR_API_URL || 'https://www.aiconfigurator.dev'
 
     async function fetchCatalog() {
+      if (!fetchPromise) {
+        fetchPromise = (async () => {
+          const [systemsRes, modelsRes] = await Promise.all([
+            fetch(`${aicUrl}/systems?include=specs`),
+            fetch(`${aicUrl}/models`),
+          ])
+
+          if (!systemsRes.ok) throw new Error(`Systems fetch failed (${systemsRes.status})`)
+          if (!modelsRes.ok) throw new Error(`Models fetch failed (${modelsRes.status})`)
+
+          const systemsData = await systemsRes.json()
+          const modelsData = await modelsRes.json()
+
+          const systems = (systemsData.systems ?? []) as Record<string, unknown>[]
+          cachedGpus = systems.map(mapSystem)
+
+          const models = (modelsData.models ?? []) as unknown[]
+          cachedModels = models.filter((m): m is string => typeof m === 'string')
+        })()
+      }
+
       try {
-        const [systemsRes, modelsRes] = await Promise.all([
-          fetch(`${aicUrl}/systems?include=specs`),
-          fetch(`${aicUrl}/models`),
-        ])
-
-        if (!systemsRes.ok) throw new Error(`Systems fetch failed (${systemsRes.status})`)
-        if (!modelsRes.ok) throw new Error(`Models fetch failed (${modelsRes.status})`)
-
-        const systemsData = await systemsRes.json()
-        const modelsData = await modelsRes.json()
-
-        if (cancelled) return
-
-        const systems = (systemsData.systems ?? []) as Record<string, unknown>[]
-        setGpuOptions(systems.map(mapSystem))
-
-        const models = (modelsData.models ?? []) as unknown[]
-        setModelOptions(models.filter((m): m is string => typeof m === 'string'))
+        await fetchPromise
+        if (!cancelled) {
+          setGpuOptions(cachedGpus!)
+          setModelOptions(cachedModels!)
+        }
       } catch (err) {
+        fetchPromise = null
         if (!cancelled) {
           setError(err instanceof Error ? err.message : 'Failed to fetch catalog')
         }

--- a/lib/hooks/useAicCatalog.ts
+++ b/lib/hooks/useAicCatalog.ts
@@ -42,7 +42,7 @@ export function useAicCatalog(): AicCatalog {
 
   useEffect(() => {
     let cancelled = false
-    const aicUrl = process.env.NEXT_PUBLIC_AICONFIGURATOR_API_URL || 'https://aiconfigurator.dev'
+    const aicUrl = process.env.NEXT_PUBLIC_AICONFIGURATOR_API_URL || 'https://www.aiconfigurator.dev'
 
     async function fetchCatalog() {
       try {

--- a/lib/hooks/useAicCatalog.ts
+++ b/lib/hooks/useAicCatalog.ts
@@ -71,10 +71,17 @@ export function useAicCatalog(): AicCatalog {
           const modelsData = await modelsRes.json()
 
           const systems = (systemsData.systems ?? []) as Record<string, unknown>[]
-          cachedGpus = systems.map(mapSystem)
+          const gpus = systems.map(mapSystem)
 
           const models = (modelsData.models ?? []) as unknown[]
-          cachedModels = models.filter((m): m is string => typeof m === 'string')
+          const modelList = models.filter((m): m is string => typeof m === 'string')
+
+          if (gpus.length === 0 || modelList.length === 0) {
+            throw new Error('AIC returned empty catalog')
+          }
+
+          cachedGpus = gpus
+          cachedModels = modelList
         })()
       }
 


### PR DESCRIPTION
## Summary
- Restore Quick Estimate in sidebar nav and homepage tool cards
- Use AIC model catalog for In catalog badge (replaces static MODEL_CATALOG)
- Cache AIC catalog in module-level store (fetch once, shared across pages)
- Fix badge race condition: show loading state until catalog arrives
- Rename GPU Calc to ConfigIQ in page title, browser tab, and add favicon
- Use CalculatorIcon for KV cache nav item (was duplicate BoltIcon)
- Make Advanced Estimate button blue, consistent with other pages
- Default KV cache page to H200 SXM and vLLM 0.24.0
- Disable spell check on all model name inputs
- Use PatternFly Label for KV cache model badge (was custom span)
- Consistent labels across all pages (GPU system, Model - Hugging Face ID)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Quick Estimate tool, accessible from the homepage and sidebar.
  * Calculator model options now use the latest catalog with loading and availability statuses.
  * Added clearer model and GPU field labels and improved model suggestions.
  * Updated branding to ConfigIQ with a new site icon.

* **Bug Fixes**
  * Improved catalog loading efficiency and retry behavior.
  * Updated calculator button styling from red to blue.
  * Updated default model, GPU, and backend selections in the KV cache calculator.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->