### PR TITLE
Use mode=quick for Quick Estimate and remove breadcrumbs

### DIFF
--- a/app/api/recommend/route.ts
+++ b/app/api/recommend/route.ts
@@ -14,7 +14,7 @@ const ERROR_STATUS_MAP: Record<string, number> = {
 
 const DEFAULT_TIMEOUT_SECONDS = 90
 
-async function proxyToAic(body: Record<string, unknown>, include: string): Promise<NextResponse> {
+async function proxyToAic(body: Record<string, unknown>, include: string, mode?: string | null): Promise<NextResponse> {
   const baseUrl = process.env.AICONFIGURATOR_API_URL
   const timeoutSeconds = parseInt(process.env.AICONFIGURATOR_TIMEOUT_SECONDS || '', 10) || DEFAULT_TIMEOUT_SECONDS
 
@@ -26,7 +26,9 @@ async function proxyToAic(body: Record<string, unknown>, include: string): Promi
   }
 
   try {
-    const res = await fetch(`${baseUrl}/recommend?include=${encodeURIComponent(include)}`, {
+    const params = new URLSearchParams({ include })
+    if (mode) params.set('mode', mode)
+    const res = await fetch(`${baseUrl}/recommend?${params.toString()}`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
       body: JSON.stringify(body),
@@ -65,9 +67,10 @@ export async function POST(req: NextRequest) {
   try {
     const body = await req.json()
     const include = req.nextUrl.searchParams.get('include')
+    const mode = req.nextUrl.searchParams.get('mode')
 
     if (include) {
-      return proxyToAic(body, include)
+      return proxyToAic(body, include, mode)
     }
 
     const validated = GpuSizerRequestSchema.parse(body)

--- a/app/quick-estimate/QuickEstimate.tsx
+++ b/app/quick-estimate/QuickEstimate.tsx
@@ -2,7 +2,6 @@
 
 import * as React from 'react';
 import {
-  Breadcrumb, BreadcrumbItem,
   Button,
   TextInput,
   FormSelect, FormSelectOption,
@@ -220,8 +219,8 @@ export default function QuickEstimate() {
   // Auto-run calculation when inputs change — calls AIC /recommend API
   React.useEffect(() => {
     const aicGpu = aicGpus.find(g => g.label === gpu);
-    const systemId = aicGpu?.systemId ?? mapGpuToSystemId(gpu);
-    if (!systemId || !model) return;
+    const systemId = aicGpu?.systemId ?? mapGpuToSystemId(gpu) ?? null;
+    if (!systemId || !model || catalogLoading) return;
 
     let cancelled = false;
     setIsCalculating(true);
@@ -896,10 +895,6 @@ export default function QuickEstimate() {
       )}
       {/* ---------- header ---------- */}
       <div className={styles.header}>
-        <Breadcrumb>
-          <BreadcrumbItem>Estimate</BreadcrumbItem>
-          <BreadcrumbItem isActive>Quick estimate</BreadcrumbItem>
-        </Breadcrumb>
         <div className={styles.headRow}>
           <div>
             <h1 className={styles.pageTitle}>Quick estimate</h1>
@@ -1188,7 +1183,12 @@ export default function QuickEstimate() {
       )}
 
       {/* ---------- result tiles ---------- */}
-      <div className={styles.tilesGrid}>
+      {isCalculating && (
+        <div style={{ textAlign: 'center', padding: '8px 0', fontSize: '13px', color: 'rgba(0,0,0,0.45)', fontFamily: 'var(--font-mono)' }}>
+          Calculating...
+        </div>
+      )}
+      <div className={styles.tilesGrid} style={{ opacity: isCalculating ? 0.5 : 1, transition: 'opacity 0.2s' }}>
         <div className={!matchesSearch('gpus required gpu count hardware h100 servers') ? styles.dimmed : ''} data-tour="result-tile-gpus">
           <FlipTile
             dark
@@ -1644,17 +1644,18 @@ export default function QuickEstimate() {
                     <span className={styles.cardTitle} style={{ fontSize: 16 }}>{sec.title}</span>
                     {'badge' in sec && sec.badge ? <Label isCompact color={sec.badgeColor as any}>{sec.badge}</Label> : null}
                     {'hasOverride' in sec && sec.hasOverride && (
-                      <Button
-                        variant="link"
-                        isInline
+                      <span
+                        role="button"
+                        tabIndex={0}
                         onClick={(e) => {
                           e.stopPropagation();
                           sec.onOverrideToggle?.();
                         }}
-                        style={{ fontSize: '13px', marginLeft: 'auto', padding: '4px 8px' }}
+                        onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.stopPropagation(); sec.onOverrideToggle?.(); } }}
+                        style={{ fontSize: '13px', marginLeft: 'auto', padding: '4px 8px', color: 'var(--gc-link)', cursor: 'pointer' }}
                       >
                         {sec.isOverridden ? '↺ Reset to auto' : '✎ Override'}
-                      </Button>
+                      </span>
                     )}
                     {!expanded.includes(sec.id) && (
                       <span className={styles.accSummary}>

--- a/lib/api/recommend-adapter.ts
+++ b/lib/api/recommend-adapter.ts
@@ -88,7 +88,7 @@ function deriveBottleneck(ttft: number, tpot: number): {
 export async function fetchRecommendAsInferenceResult(
   input: RecommendAdapterInput
 ): Promise<InferenceConfigResult> {
-  const res = await fetch('/api/recommend?include=config,memory', {
+  const res = await fetch('/api/recommend?mode=quick&include=config,memory', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
@@ -117,13 +117,19 @@ export async function fetchRecommendAsInferenceResult(
   const best = configs[0]
   const sc = best.serving_config
   const mb = best.memory_breakdown
-  const tp = best.tp ?? sc?.tensor_parallel_size ?? best.num_total_gpus ?? 1
-  const pp = best.pp ?? 1
   const replicas = best.replicas_needed ?? 1
+  const totalGpusNeeded = best.total_gpus_needed ?? best.num_total_gpus ?? 1
+  const gpusPerWorker = best.num_total_gpus ?? 1
+  const tp = best.tp ?? gpusPerWorker
+  const pp = best.pp ?? 1
   const totalVramGb = gpuVramGb(input.system)
   const gmu = sc?.gpu_memory_utilization ?? 0.9
   const hasBreakdown = !!mb
-  const weightGb = hasBreakdown ? mb.weights_bytes / GB : (best.memory ?? 0) * 0.5
+  const weightGb = hasBreakdown
+    ? mb.weights_bytes / GB
+    : typeof best.memory === 'number'
+      ? best.memory * 0.5
+      : totalVramGb * tp * 0.5
   const kvCacheGb = hasBreakdown && typeof mb.kv_cache_bytes === 'number' ? mb.kv_cache_bytes / GB : 0
   const usablePerGpu = totalVramGb * gmu
   const warnings: string[] = []


### PR DESCRIPTION
Pass mode=quick to AIC /recommend for faster agg-only single-node search. Remove the breadcrumb that no other page has.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **UI Improvements**
  - Simplified the Quick Estimate header by removing breadcrumb navigation.

- **Bug Fixes**
  - Updated recommendation requests to use quick mode while preserving existing configuration and memory settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->