### PR TITLE
feat: Settings page with global defaults for model, HF token, and backend

### DIFF
--- a/app/calculator/AdvancedEstimate.tsx
+++ b/app/calculator/AdvancedEstimate.tsx
@@ -17,6 +17,7 @@ import { GPU_CATALOG, GPU_OPTIONS_ADV } from '@/lib/gpu-math/gpus';
 import { fetchModelConfig } from '@/lib/huggingface/fetch-config';
 import { useGpuSizer } from '@/contexts/GpuSizerContext';
 import { useAicCatalog } from '@/lib/hooks/useAicCatalog';
+import { useSettings } from '@/contexts/SettingsContext';
 import { GpuChipLoader } from '@/components/GpuChipLoader/GpuChipLoader';
 
 
@@ -124,22 +125,26 @@ function friendlyErrorHint(code: string | null): string {
 // ─── Component ───────────────────────────────────────────────────────────────
 
 export default function AdvancedEstimate() {
+  const { hydrated, hfToken, defaultModel: settingsDefaultModel, inferenceBackend } = useSettings();
   const { modelOptions: aicModels, isLoading: catalogLoading } = useAicCatalog();
   const MODEL_OPTIONS = aicModels;
 
   // Input state
-  const [model, setModel] = React.useState('Qwen/Qwen3-32B');
+  const [model, setModel] = React.useState('');
+
+  // Set model from settings after context has loaded from localStorage
+  const modelFromSettings = React.useRef(false);
+  React.useEffect(() => {
+    if (!hydrated || modelFromSettings.current) return;
+    modelFromSettings.current = true;
+    setModel(settingsDefaultModel);
+  }, [hydrated, settingsDefaultModel]);
   const [gpuSystem, setGpuSystem] = React.useState(
     GPU_OPTIONS_ADV.find(g => g.systemId === 'h200_sxm')?.systemId ?? GPU_OPTIONS_ADV[0]?.systemId ?? ''
   );
   const [isl, setIsl] = React.useState(2048);
   const [osl, setOsl] = React.useState(128);
   const [ttft, setTtft] = React.useState(1000);
-
-  // HF token
-  const [hfToken, setHfToken] = React.useState('');
-  const [hfReveal, setHfReveal] = React.useState(false);
-  const [showHfSection, setShowHfSection] = React.useState(false);
 
   // Model status + HF config
   const [modelStatus, setModelStatus] = React.useState<'idle' | 'fetching' | 'catalog' | 'fetched' | 'error'>('idle');
@@ -154,16 +159,6 @@ export default function AdvancedEstimate() {
   // Live pricing
   const [livePricing, setLivePricing] = React.useState<Record<string, number>>({});
 
-  // Load HF token from localStorage
-  React.useEffect(() => {
-    if (typeof window !== 'undefined') {
-      const saved = localStorage.getItem('hf_token');
-      if (saved?.startsWith('hf_')) {
-        setHfToken(saved);
-        setShowHfSection(true);
-      }
-    }
-  }, []);
 
   // Model status check + fetch HF config
   React.useEffect(() => {
@@ -206,20 +201,12 @@ export default function AdvancedEstimate() {
     fetchPricing();
   }, []);
 
-  // Save HF token
-  const handleTokenChange = (val: string) => {
-    setHfToken(val);
-    if (typeof window !== 'undefined' && val.startsWith('hf_')) {
-      localStorage.setItem('hf_token', val);
-    }
-  };
-
   // Get GPU + model spec from catalog
   const currentGpuOption = GPU_OPTIONS_ADV.find(g => g.systemId === gpuSystem) || GPU_OPTIONS_ADV[0];
   const gpuSpec = GPU_CATALOG.find(g => g.id === currentGpuOption.id);
 
   const handleCalculate = () => {
-    startSizing({ model_path: model, system: gpuSystem, isl, osl, ttft, tpot: 30, target_concurrency: 32 });
+    startSizing({ model_path: model, system: gpuSystem, isl, osl, ttft, tpot: 30, target_concurrency: 32, backend: inferenceBackend });
   };
 
   // Local memory analysis using the same engine as Quick Estimate
@@ -287,6 +274,14 @@ export default function AdvancedEstimate() {
             </div>
             <div className={styles.helperText}>
               Popular models: Llama 3.1, Mistral, Qwen 2.5, Gemma 2 — type to autocomplete
+              {hfToken ? (
+                <span style={{ marginLeft: '8px', color: '#0066cc', fontWeight: 500 }}>🔑 HF token active</span>
+              ) : (
+                <span style={{ marginLeft: '8px' }}>
+                  Gated model?{' '}
+                  <a href="/settings" style={{ color: '#0066cc' }}>Add your HF token in Settings →</a>
+                </span>
+              )}
             </div>
           </div>
 
@@ -378,40 +373,6 @@ export default function AdvancedEstimate() {
               </div>
             </div>
 
-            {/* HF Token */}
-            <div className={styles.hfSection}>
-              <div className={styles.fieldLabel} style={{ marginBottom: 8 }}>
-                Hugging Face token (optional — for gated or private models)
-              </div>
-              <div className={styles.hfRow}>
-                <input
-                  type={hfReveal ? 'text' : 'password'}
-                  className={styles.hfInput}
-                  value={hfToken}
-                  onChange={e => handleTokenChange(e.target.value)}
-                  placeholder="hf_..."
-                />
-                <button
-                  type="button"
-                  onClick={() => setHfReveal(!hfReveal)}
-                  style={{ background: 'none', border: '1px solid #d2d2d2', borderRadius: 4, padding: '8px 10px', cursor: 'pointer' }}
-                  aria-label={hfReveal ? 'Hide token' : 'Show token'}
-                >
-                  {hfReveal ? <EyeSlashIcon /> : <EyeIcon />}
-                </button>
-                <a
-                  href="https://huggingface.co/settings/tokens"
-                  target="_blank"
-                  rel="noopener"
-                  style={{ color: '#0066cc', fontWeight: 500, whiteSpace: 'nowrap', fontSize: 14 }}
-                >
-                  Get a token
-                </a>
-              </div>
-              <div className={styles.hfNote}>
-                Stored in this browser only — never sent to our servers.
-              </div>
-            </div>
 
             {/* Additional constraints */}
             <Accordion style={{ marginTop: 12 }}>

--- a/app/calculator/AdvancedEstimate.tsx
+++ b/app/calculator/AdvancedEstimate.tsx
@@ -18,6 +18,12 @@ import { fetchModelConfig } from '@/lib/huggingface/fetch-config';
 import { useGpuSizer } from '@/contexts/GpuSizerContext';
 import { useAicCatalog } from '@/lib/hooks/useAicCatalog';
 import { useSettings } from '@/contexts/SettingsContext';
+import { getAppConfig } from '@/lib/app-config';
+
+function modelSuggestions(): string {
+  const names = getAppConfig().suggestedModelNames;
+  return names.length > 0 ? names.join(', ') : 'Nemotron, DeepSeek V4, Gemma 4, Kimi';
+}
 import { GpuChipLoader } from '@/components/GpuChipLoader/GpuChipLoader';
 
 
@@ -147,7 +153,7 @@ export default function AdvancedEstimate() {
   const [ttft, setTtft] = React.useState(1000);
 
   // Model status + HF config
-  const [modelStatus, setModelStatus] = React.useState<'idle' | 'fetching' | 'catalog' | 'fetched' | 'error'>('idle');
+  const [modelStatus, setModelStatus] = React.useState<'idle' | 'supported' | 'catalog' | 'fetching' | 'fetched' | 'error'>('idle');
 
   // GPU sizer (persistent across navigation)
   const { isLoading, result, error, errorCode, elapsed, debugRequest, debugResponse, debugStatus, debugDuration, startSizing } = useGpuSizer();
@@ -165,20 +171,16 @@ export default function AdvancedEstimate() {
     if (catalogLoading) { setModelStatus('idle'); return; }
     const timer = setTimeout(() => {
       if (!model.includes('/')) { setModelStatus('idle'); return; }
+      if (getAppConfig().supportedModels.includes(model)) { setModelStatus('supported'); return; }
       const inCatalog = MODEL_OPTIONS.includes(model);
-      setModelStatus(inCatalog ? 'catalog' : 'fetching');
-      if (!inCatalog) {
-        fetchModelConfig(model, hfToken).then(r => {
-          if (r.success && r.config) {
-            setModelStatus('fetched');
-          } else {
-            setModelStatus('error');
-          }
-        });
-      }
+      if (inCatalog) { setModelStatus('catalog'); return; }
+      setModelStatus('fetching');
+      fetchModelConfig(model, hfToken).then(r => {
+        setModelStatus(r.success && r.config ? 'fetched' : 'error');
+      });
     }, 500);
     return () => clearTimeout(timer);
-  }, [model, hfToken, MODEL_OPTIONS, catalogLoading]);
+  }, [model, hfToken, MODEL_OPTIONS, catalogLoading, hydrated]);
 
   // Fetch live pricing
   React.useEffect(() => {
@@ -258,14 +260,17 @@ export default function AdvancedEstimate() {
                 {MODEL_OPTIONS.map(m => <option key={m} value={m} />)}
               </datalist>
               <div className={styles.autoChipWrapper}>
+                {modelStatus === 'supported' && (
+                  <Label color="blue" isCompact icon={<CheckCircleIcon />}>Supported</Label>
+                )}
                 {modelStatus === 'catalog' && (
                   <Label color="green" isCompact icon={<CheckCircleIcon />}>In catalog</Label>
                 )}
                 {modelStatus === 'fetching' && (
-                  <Label color="blue" isCompact>Fetching...</Label>
+                  <Label color="grey" isCompact>Checking...</Label>
                 )}
                 {modelStatus === 'fetched' && (
-                  <Label color="cyan" isCompact icon={<CheckCircleIcon />}>From HuggingFace</Label>
+                  <Label color="gold" isCompact icon={<CheckCircleIcon />}>From HuggingFace</Label>
                 )}
                 {modelStatus === 'error' && (
                   <Label color="red" isCompact icon={<ExclamationTriangleIcon />}>Not found</Label>
@@ -273,7 +278,7 @@ export default function AdvancedEstimate() {
               </div>
             </div>
             <div className={styles.helperText}>
-              Popular models: Llama 3.1, Mistral, Qwen 2.5, Gemma 2 — type to autocomplete
+              Supported: {modelSuggestions()} — type to autocomplete
               {hfToken ? (
                 <span style={{ marginLeft: '8px', color: '#0066cc', fontWeight: 500 }}>🔑 HF token active</span>
               ) : (

--- a/app/kv-cache/KvCacheCalc.tsx
+++ b/app/kv-cache/KvCacheCalc.tsx
@@ -7,6 +7,8 @@ import { GPU_OPTIONS_KV } from '@/lib/gpu-math/gpus'
 import { formatBytes } from '@/lib/utils/format'
 import { useCountUp } from '@/app/quick-estimate/quickEstimateHelpers'
 import { useAicCatalog } from '@/lib/hooks/useAicCatalog'
+import { useSettings, type InferenceBackend } from '@/contexts/SettingsContext'
+import { getAppConfig } from '@/lib/app-config'
 import type { KvCacheCalcResult } from '@/lib/api/kv-cache-calc'
 import styles from './KvCacheCalc.module.css'
 
@@ -20,15 +22,26 @@ const BREAKDOWN_COLORS: Record<string, string> = {
 }
 
 export default function KvCacheCalc() {
+  const { hydrated, defaultModel: settingsDefaultModel, inferenceBackend, backendVersion: settingsBackendVersion } = useSettings()
   const { modelOptions: aicModels, isLoading: catalogLoading } = useAicCatalog()
   const MODEL_OPTIONS = aicModels
 
-  const [model, setModel] = React.useState('Qwen/Qwen3-32B')
+  const [model, setModel] = React.useState('')
   const [system, setSystem] = React.useState(
     GPU_OPTIONS_KV.find(g => g.systemId === 'h200_sxm')?.systemId ?? GPU_OPTIONS_KV[0]?.systemId ?? ''
   )
   const [backend, setBackend] = React.useState('vllm')
   const [backendVersion, setBackendVersion] = React.useState('0.24.0')
+
+  // Initialise model, backend, and version from settings once context has loaded from localStorage
+  const fromSettings = React.useRef(false)
+  React.useEffect(() => {
+    if (!hydrated || fromSettings.current) return
+    fromSettings.current = true
+    setModel(settingsDefaultModel)
+    setBackend(inferenceBackend)
+    setBackendVersion(settingsBackendVersion)
+  }, [hydrated, settingsDefaultModel, inferenceBackend, settingsBackendVersion])
   const [maxNumTokens, setMaxNumTokens] = React.useState(8192)
   const [maxBatchSize, setMaxBatchSize] = React.useState(128)
   const [tpSize, setTpSize] = React.useState(1)
@@ -220,7 +233,7 @@ export default function KvCacheCalc() {
                   id="kv-backend-ver"
                   value={backendVersion}
                   onChange={e => setBackendVersion(e.target.value)}
-                  placeholder="latest"
+                  placeholder={getAppConfig().backendVersions[backend] ?? 'latest'}
                   className={styles.numberInput}
                 />
               </div>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -41,6 +41,7 @@ import "./globals.css";
 import "./theme.css";
 import { AppShell } from "@/components/layout/AppShell";
 import { GpuSizerProvider } from "@/contexts/GpuSizerContext";
+import { SettingsProvider } from "@/contexts/SettingsContext";
 
 const redHatDisplay = Red_Hat_Display({
   subsets: ["latin"],
@@ -89,7 +90,9 @@ export default function RootLayout({
       </head>
       <body>
         <GpuSizerProvider>
-          <AppShell>{children}</AppShell>
+          <SettingsProvider>
+            <AppShell>{children}</AppShell>
+          </SettingsProvider>
         </GpuSizerProvider>
       </body>
     </html>

--- a/app/quick-estimate/QuickEstimate.tsx
+++ b/app/quick-estimate/QuickEstimate.tsx
@@ -33,10 +33,16 @@ import { saveEstimate, getSavedEstimateCount } from '@/lib/saved-estimates';
 import { fetchRecommendAsInferenceResult } from '@/lib/api/recommend-adapter';
 import { useAicCatalog } from '@/lib/hooks/useAicCatalog';
 import { useSettings } from '@/contexts/SettingsContext';
+import { getAppConfig } from '@/lib/app-config';
 import type { InferenceConfigResult } from '@/lib/gpu-math/inference-config';
 import Link from 'next/link';
 
 const STATIC_GPU_OPTIONS = GPU_OPTIONS_QE.map(g => g.label);
+
+function modelSuggestions(): string {
+  const names = getAppConfig().suggestedModelNames;
+  return names.length > 0 ? names.join(', ') : 'Nemotron, DeepSeek V4, Gemma 4, Kimi';
+}
 
 function mapGpuToCatalogId(uiGpuName: string): string {
   const match = GPU_OPTIONS_QE.find(g => g.label === uiGpuName);
@@ -168,13 +174,17 @@ export default function QuickEstimate() {
   // Add loading state
   const [isCalculating, setIsCalculating] = React.useState(false);
 
-  // Fetch HF config when model changes - ALWAYS fetch for accuracy
+  // Fetch HF config when model changes
   React.useEffect(() => {
-    // Reset fallback state
     setIsUsingFallback(false);
     setFallbackReason('');
 
-    // Always fetch for ALL models (catalog + custom)
+    // Skip HF fetch for supported and catalog models — we know they work
+    if (getAppConfig().supportedModels.includes(model) || MODEL_OPTIONS.includes(model)) {
+      setIsFetchingConfig(false);
+      return;
+    }
+
     const fetchConfig = async () => {
       setIsFetchingConfig(true);
       console.log('🔄 Fetching config from HuggingFace for:', model);
@@ -201,7 +211,7 @@ export default function QuickEstimate() {
     // Debounce to avoid fetching while user is typing
     const timer = setTimeout(fetchConfig, 500);
     return () => clearTimeout(timer);
-  }, [model, hfToken]);
+  }, [model, hfToken, hydrated]);
 
   // Auto-run calculation when inputs change — calls AIC /recommend API
   React.useEffect(() => {
@@ -939,12 +949,14 @@ export default function QuickEstimate() {
                 {MODEL_OPTIONS.map((m) => <option key={m} value={m} />)}
               </datalist>
               <div className={styles.autoChipWrapper}>
-                {MODEL_OPTIONS.includes(model) ? (
+                {getAppConfig().supportedModels.includes(model) ? (
+                  <Label color="blue" icon={<CheckCircleIcon />}>Supported</Label>
+                ) : MODEL_OPTIONS.includes(model) ? (
                   <Label color="green" icon={<CheckCircleIcon />}>In catalog</Label>
                 ) : isFetchingConfig || catalogLoading ? (
-                  <Label color="blue">🔄 Checking model...</Label>
+                  <Label color="grey">Checking...</Label>
                 ) : hfConfig ? (
-                  <Label color="cyan" icon={<CheckCircleIcon />}>From HuggingFace</Label>
+                  <Label color="gold" icon={<CheckCircleIcon />}>From HuggingFace</Label>
                 ) : testError ? (
                   <Label color="red" icon={<ExclamationTriangleIcon />}>Not found</Label>
                 ) : (
@@ -953,7 +965,7 @@ export default function QuickEstimate() {
               </div>
             </div>
             <div className={styles.helperText}>
-              Popular models: Llama 3.1, Mistral, Qwen 2.5, Gemma 2 — type to autocomplete
+              Supported: {modelSuggestions()} — type to autocomplete
               {hfToken ? (
                 <span style={{ marginLeft: '8px', color: '#0066cc', fontWeight: 500 }}>
                   🔑 HF token active
@@ -1126,7 +1138,7 @@ export default function QuickEstimate() {
               <strong>✅ What to do now:</strong>
               <ol style={{ margin: '8px 0 0 0', paddingLeft: '20px', lineHeight: '1.6' }}>
                 <li><strong>Use the dropdown:</strong> Select a model from the autocomplete suggestions</li>
-                <li><strong>Popular models:</strong> Llama 3.1, Mistral, Qwen 2.5, DeepSeek, Gemma 2</li>
+                <li><strong>Supported models:</strong> {modelSuggestions()}</li>
                 <li><strong>Check spelling:</strong> Model names are case-sensitive (e.g., &ldquo;meta-llama&rdquo; not &ldquo;Meta-Llama&rdquo;)</li>
                 <li><strong>GGUF models?</strong> Use the original base model, not the GGUF repo (e.g., &ldquo;google/gemma-2-12b-it&rdquo; not &ldquo;unsloth/gemma-...-GGUF&rdquo;)</li>
                 <li><strong>Want a specific model?</strong> Let us know and we&apos;ll add it to the catalog</li>

--- a/app/quick-estimate/QuickEstimate.tsx
+++ b/app/quick-estimate/QuickEstimate.tsx
@@ -32,6 +32,7 @@ import { fetchModelConfig, type HFModelConfig } from '@/lib/huggingface/fetch-co
 import { saveEstimate, getSavedEstimateCount } from '@/lib/saved-estimates';
 import { fetchRecommendAsInferenceResult } from '@/lib/api/recommend-adapter';
 import { useAicCatalog } from '@/lib/hooks/useAicCatalog';
+import { useSettings } from '@/contexts/SettingsContext';
 import type { InferenceConfigResult } from '@/lib/gpu-math/inference-config';
 import Link from 'next/link';
 
@@ -83,6 +84,7 @@ const QUICK_ESTIMATE_TOUR: TourStep[] = [
 
 export default function QuickEstimate() {
   console.log('🔵 QuickEstimate component mounting');
+  const { hydrated, hfToken, defaultModel: settingsDefaultModel, inferenceBackend } = useSettings();
   const { gpuOptions: aicGpus, modelOptions: aicModels, isLoading: catalogLoading } = useAicCatalog();
 
   const GPU_OPTIONS = React.useMemo(
@@ -91,8 +93,16 @@ export default function QuickEstimate() {
   );
   const MODEL_OPTIONS = aicModels;
 
-  const [model, setModel] = React.useState('Qwen/Qwen3-32B');
+  const [model, setModel] = React.useState('');
   const [gpu, setGpu] = React.useState('');
+
+  // Set model from settings after context has loaded from localStorage
+  const modelFromSettings = React.useRef(false);
+  React.useEffect(() => {
+    if (!hydrated || modelFromSettings.current) return;
+    modelFromSettings.current = true;
+    setModel(settingsDefaultModel);
+  }, [hydrated, settingsDefaultModel]);
 
   React.useEffect(() => {
     if (GPU_OPTIONS.length > 0 && !gpu) {
@@ -102,9 +112,6 @@ export default function QuickEstimate() {
   }, [GPU_OPTIONS, gpu]);
 
   const [fav, setFav] = React.useState(false);
-  const [showHf, setShowHf] = React.useState(false);
-  const [hfToken, setHfToken] = React.useState('');
-  const [hfReveal, setHfReveal] = React.useState(false);
   const [expanded, setExpanded] = React.useState<string[]>([]);
   const [showApi, setShowApi] = React.useState(false);
   const [searchQuery, setSearchQuery] = React.useState('');
@@ -161,26 +168,6 @@ export default function QuickEstimate() {
   // Add loading state
   const [isCalculating, setIsCalculating] = React.useState(false);
 
-  // Load saved HF token from localStorage on mount
-  React.useEffect(() => {
-    if (typeof window !== 'undefined') {
-      const savedToken = localStorage.getItem('hf_token');
-      if (savedToken && savedToken.startsWith('hf_')) {
-        setHfToken(savedToken);
-        console.log('🔑 Loaded HF token from localStorage');
-      }
-    }
-  }, []);
-
-  // Handle HF token changes and save to localStorage
-  const handleTokenChange = (newToken: string) => {
-    setHfToken(newToken);
-    if (typeof window !== 'undefined' && newToken && newToken.startsWith('hf_')) {
-      localStorage.setItem('hf_token', newToken);
-      console.log('💾 Saved HF token to localStorage');
-    }
-  };
-
   // Fetch HF config when model changes - ALWAYS fetch for accuracy
   React.useEffect(() => {
     // Reset fallback state
@@ -233,6 +220,7 @@ export default function QuickEstimate() {
           isl: testISL,
           osl: testOSL,
           concurrent_users: testConcurrentUsers,
+          backend: inferenceBackend,
         });
         if (!cancelled) {
           setTestResult(result);
@@ -966,9 +954,14 @@ export default function QuickEstimate() {
             </div>
             <div className={styles.helperText}>
               Popular models: Llama 3.1, Mistral, Qwen 2.5, Gemma 2 — type to autocomplete
-              {hfToken && hfToken.trim() && (
+              {hfToken ? (
                 <span style={{ marginLeft: '8px', color: '#0066cc', fontWeight: 500 }}>
-                  🔑 Token active ({hfToken.startsWith('hf_') ? '✓ valid format' : '⚠️ check format'})
+                  🔑 HF token active
+                </span>
+              ) : (
+                <span style={{ marginLeft: '8px' }}>
+                  Gated model?{' '}
+                  <a href="/settings" style={{ color: '#0066cc' }}>Add your HF token in Settings →</a>
                 </span>
               )}
             </div>
@@ -994,45 +987,6 @@ export default function QuickEstimate() {
           </div>
         </div>
 
-        <div style={{ marginTop: '18px' }}>
-          <label className={styles.fieldLabel} style={{ marginBottom: '8px', display: 'block' }}>
-            Hugging Face Token (optional — for gated or private models)
-          </label>
-          <div className={styles.hfPanel}>
-            <div className={styles.fieldRow} style={{ flex: 1 }}>
-              <input
-                type={hfReveal ? 'text' : 'password'}
-                value={hfToken}
-                onChange={(e) => handleTokenChange(e.target.value)}
-                placeholder="hf_xxxxxxxxxxxxxxxxxxxx"
-                aria-label="Hugging Face token"
-                className={styles.hfInput}
-                style={{
-                  flex: 1,
-                  border: '1px solid #b8bbbe',
-                  borderRadius: '4px',
-                  padding: '8px 12px',
-                  fontSize: '14px',
-                  fontFamily: 'var(--sans)',
-                  minHeight: '42px'
-                }}
-              />
-              <Button
-                variant="control"
-                aria-label={hfReveal ? 'Hide token' : 'Show token'}
-                onClick={() => {
-                  console.log('Toggle clicked, current state:', hfReveal);
-                  setHfReveal(!hfReveal);
-                }}
-                icon={hfReveal ? <EyeSlashIcon /> : <EyeIcon />}
-              />
-            </div>
-            <Button variant="link" component="a" href="https://huggingface.co/settings/tokens" target="_blank">
-              Get a token
-            </Button>
-          </div>
-          <p className={styles.hfNote}>Stored in this browser only — never sent to our servers.</p>
-        </div>
       </div>
 
       {/* ---------- warning strip ---------- */}

--- a/app/settings/Settings.module.css
+++ b/app/settings/Settings.module.css
@@ -1,0 +1,184 @@
+/* ============================================================================
+   Settings page — uses global theme tokens from theme.css / globals.css.
+   No local re-aliases. No font-size below 11.5px; no text lighter than
+   --gc-text-2 for labels, values, or descriptions.
+   ============================================================================ */
+
+.page {
+  font-family: var(--gc-font-sans);
+  color: var(--gc-text);
+  font-size: 15px;
+  line-height: 1.5;
+  max-width: 860px;
+  padding: 32px 32px 64px;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+/* ── Page header ── */
+.header    { margin-bottom: 28px; }
+.pageTitle {
+  font-family: var(--gc-font-display);
+  font-size: 30px;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  margin: 0 0 6px;
+  color: var(--gc-text);
+}
+.subtitle  { font-size: 15px; color: var(--gc-text-2); margin: 0; }
+
+/* ── Section list ── */
+.sections { display: flex; flex-direction: column; gap: 12px; }
+
+/* ── Individual section card ── */
+.section {
+  background: white;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 20px 24px 22px;
+}
+
+.sectionHead {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 14px;
+}
+
+.sectionTitle {
+  font-family: var(--gc-font-sans);
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--gc-text);
+  margin-bottom: 3px;
+}
+
+.sectionDesc {
+  font-size: 13px;
+  color: var(--gc-text-2);
+  line-height: 1.5;
+  max-width: 560px;
+}
+
+/* ── Field layout ── */
+.fieldWrap { display: flex; flex-direction: column; gap: 6px; }
+
+.fieldLabel {
+  font-family: var(--gc-font-mono);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--gc-text-2);
+  display: block;
+}
+
+/* ── Model input with in-line catalog chip ── */
+.modelInputWrapper {
+  position: relative;
+  max-width: 480px;
+}
+.modelInput {
+  width: 100%;
+  height: 42px;
+  border: 1px solid var(--border-light, #b8bbbe);
+  border-radius: 4px;
+  padding: 7px 130px 7px 12px;
+  font-size: 14px;
+  font-family: var(--gc-font-sans);
+  background: white;
+  color: var(--gc-text);
+  box-sizing: border-box;
+}
+.modelInput:focus {
+  outline: 2px solid var(--gc-link);
+  outline-offset: 1px;
+  border-color: var(--gc-link);
+}
+.autoChipWrapper {
+  position: absolute;
+  right: 8px;
+  top: 50%;
+  transform: translateY(-50%);
+  pointer-events: none;
+}
+.autoChipWrapper :global(.pf-v5-c-label) {
+  font-size: 12px;
+  font-weight: 500;
+}
+
+/* ── Shared input base ── */
+.textInput {
+  height: 42px;
+  width: 100%;
+  border: 1px solid var(--border-light, #b8bbbe);
+  border-radius: 4px;
+  padding: 7px 12px;
+  font-size: 14px;
+  font-family: var(--gc-font-sans);
+  background: white;
+  color: var(--gc-text);
+  box-sizing: border-box;
+}
+.textInput:focus {
+  outline: 2px solid var(--gc-link);
+  outline-offset: 1px;
+  border-color: var(--gc-link);
+}
+
+/* ── Token row (input + reveal button side-by-side) ── */
+.tokenRow {
+  display: flex;
+  align-items: stretch;
+  max-width: 480px;
+}
+.tokenRow .textInput {
+  border-right: none;
+  border-radius: 4px 0 0 4px;
+  flex: 1;
+  max-width: none;
+}
+.tokenRow :global(.pf-v5-c-button) {
+  border: 1px solid var(--border-light, #b8bbbe);
+  border-radius: 0 4px 4px 0;
+  height: 42px;
+  flex-shrink: 0;
+  background: white;
+}
+
+/* ── Backend + version side-by-side ── */
+.backendRow  { display: flex; gap: 16px; align-items: flex-end; flex-wrap: wrap; }
+.backendField { display: flex; flex-direction: column; gap: 6px; }
+.versionField { display: flex; flex-direction: column; gap: 6px; }
+.versionField .textInput { width: 120px; }
+
+/* ── Backend select ── */
+.selectInput {
+  height: 42px;
+  min-width: 200px;
+  border: 1px solid var(--border-light, #b8bbbe);
+  border-radius: 4px;
+  padding: 7px 12px;
+  font-size: 14px;
+  font-family: var(--gc-font-sans);
+  background: white;
+  color: var(--gc-text);
+  cursor: pointer;
+  appearance: auto;
+}
+.selectInput:focus {
+  outline: 2px solid var(--gc-link);
+  outline-offset: 1px;
+  border-color: var(--gc-link);
+}
+
+/* ── Helper text & link ── */
+.helperText { font-size: 13px; color: var(--gc-text-3); line-height: 1.4; }
+
+.link {
+  color: var(--gc-link);
+  text-decoration: none;
+  font-size: 13px;
+}
+.link:hover { text-decoration: underline; }

--- a/app/settings/Settings.tsx
+++ b/app/settings/Settings.tsx
@@ -1,0 +1,248 @@
+'use client';
+
+import * as React from 'react';
+import { Button, Label } from '@patternfly/react-core';
+import { EyeIcon, EyeSlashIcon, CheckCircleIcon, ExclamationTriangleIcon } from '@patternfly/react-icons';
+import { useSettings, type InferenceBackend } from '@/contexts/SettingsContext';
+import { getAppConfig } from '@/lib/app-config';
+import { useAicCatalog } from '@/lib/hooks/useAicCatalog';
+import { fetchModelConfig } from '@/lib/huggingface/fetch-config';
+import styles from './Settings.module.css';
+
+type ModelStatus = 'idle' | 'catalog' | 'fetching' | 'fetched' | 'error';
+
+const BACKENDS: { value: InferenceBackend; label: string; description: string }[] = [
+  { value: 'vllm', label: 'vLLM', description: 'Open-source LLM inference engine; default for most deployments.' },
+  { value: 'tensorrt-llm', label: 'TensorRT-LLM', description: "NVIDIA's optimized inference library for maximum GPU throughput." },
+  { value: 'sglang', label: 'SGLang', description: 'Structured generation serving framework with fast batch processing.' },
+];
+
+export function Settings() {
+  const { hydrated, defaultModel, setDefaultModel, hfToken, setHfToken, inferenceBackend, setInferenceBackend, backendVersion, setBackendVersion } = useSettings();
+  const { modelOptions, isLoading: catalogLoading } = useAicCatalog();
+
+  const [localModel, setLocalModel] = React.useState('');
+  const [modelStatus, setModelStatus] = React.useState<ModelStatus>('idle');
+  const [hfReveal, setHfReveal] = React.useState(false);
+  const [modelSaved, setModelSaved] = React.useState(false);
+  const [tokenSaved, setTokenSaved] = React.useState(false);
+  const [backendSaved, setBackendSaved] = React.useState(false);
+
+  // Sync local model input once context has loaded from localStorage
+  const modelSynced = React.useRef(false);
+  React.useEffect(() => {
+    if (!hydrated || modelSynced.current) return;
+    modelSynced.current = true;
+    setLocalModel(defaultModel);
+  }, [hydrated, defaultModel]);
+
+  // Debounced auto-save for model (1500ms — gives the user time to finish typing)
+  React.useEffect(() => {
+    if (!modelSynced.current || localModel === defaultModel) return;
+    const timer = setTimeout(() => {
+      setDefaultModel(localModel);
+      setModelSaved(true);
+      const clear = setTimeout(() => setModelSaved(false), 3000);
+      return () => clearTimeout(clear);
+    }, 1500);
+    return () => clearTimeout(timer);
+  }, [localModel, defaultModel, setDefaultModel]);
+
+  // Model catalog + HF status check (same debounced pattern as other pages)
+  React.useEffect(() => {
+    if (catalogLoading) { setModelStatus('idle'); return; }
+    if (!localModel || !localModel.includes('/')) { setModelStatus('idle'); return; }
+    const timer = setTimeout(() => {
+      const inCatalog = modelOptions.includes(localModel);
+      if (inCatalog) { setModelStatus('catalog'); return; }
+      setModelStatus('fetching');
+      fetchModelConfig(localModel, hfToken).then(r => {
+        setModelStatus(r.success && r.config ? 'fetched' : 'error');
+      });
+    }, 500);
+    return () => clearTimeout(timer);
+  }, [localModel, hfToken, modelOptions, catalogLoading]);
+
+  const handleTokenChange = (v: string) => {
+    setHfToken(v);
+    if (v.startsWith('hf_')) {
+      setTokenSaved(true);
+      setTimeout(() => setTokenSaved(false), 2000);
+    }
+  };
+
+  const handleBackendChange = (v: InferenceBackend) => {
+    setInferenceBackend(v); // also resets backendVersion to the default for v
+    setBackendSaved(true);
+    setTimeout(() => setBackendSaved(false), 3000);
+  };
+
+  const handleVersionChange = (v: string) => {
+    setBackendVersion(v);
+    setBackendSaved(true);
+    setTimeout(() => setBackendSaved(false), 3000);
+  };
+
+  const selectedBackend = BACKENDS.find(b => b.value === inferenceBackend);
+
+  return (
+    <div className={styles.page}>
+      <div className={styles.header}>
+        <h1 className={styles.pageTitle}>Settings</h1>
+        <p className={styles.subtitle}>
+          Configure once — defaults apply across all tools automatically.
+        </p>
+      </div>
+
+      <div className={styles.sections}>
+        {/* ── Default model ── */}
+        <div className={styles.section}>
+          <div className={styles.sectionHead}>
+            <div>
+              <div className={styles.sectionTitle}>Default model</div>
+              <div className={styles.sectionDesc}>
+                Pre-filled in Quick Estimate and Calculator. Use any Hugging Face model ID.
+              </div>
+            </div>
+            {modelSaved && (
+              <Label color="green" icon={<CheckCircleIcon />}>Saved</Label>
+            )}
+          </div>
+          <div className={styles.fieldWrap}>
+            <label className={styles.fieldLabel} htmlFor="settings-model">
+              Hugging Face model ID
+            </label>
+            <div className={styles.modelInputWrapper}>
+              <input
+                id="settings-model"
+                type="text"
+                list="settings-model-options"
+                value={localModel}
+                onChange={e => setLocalModel(e.target.value)}
+                placeholder={catalogLoading ? 'Loading catalog…' : 'e.g. Qwen/Qwen3-32B'}
+                className={styles.modelInput}
+                spellCheck={false}
+                autoComplete="off"
+              />
+              <datalist id="settings-model-options">
+                {modelOptions.map(m => <option key={m} value={m} />)}
+              </datalist>
+              <div className={styles.autoChipWrapper}>
+                {modelStatus === 'catalog' && (
+                  <Label color="green" isCompact icon={<CheckCircleIcon />}>In catalog</Label>
+                )}
+                {modelStatus === 'fetching' && (
+                  <Label color="blue" isCompact>Checking…</Label>
+                )}
+                {modelStatus === 'fetched' && (
+                  <Label color="cyan" isCompact icon={<CheckCircleIcon />}>From HuggingFace</Label>
+                )}
+                {modelStatus === 'error' && (
+                  <Label color="red" isCompact icon={<ExclamationTriangleIcon />}>Not found</Label>
+                )}
+              </div>
+            </div>
+            <div className={styles.helperText}>
+              All tools use this model by default. Type to autocomplete from the AIC catalog.
+            </div>
+          </div>
+        </div>
+
+        {/* ── HF token ── */}
+        <div className={styles.section}>
+          <div className={styles.sectionHead}>
+            <div>
+              <div className={styles.sectionTitle}>Hugging Face token</div>
+              <div className={styles.sectionDesc}>
+                Required for gated or private models. Stored in this browser only — never sent to our servers.
+              </div>
+            </div>
+            {tokenSaved && (
+              <Label color="green" icon={<CheckCircleIcon />}>Saved</Label>
+            )}
+          </div>
+          <div className={styles.fieldWrap}>
+            <label className={styles.fieldLabel} htmlFor="settings-hf-token">API token</label>
+            <div className={styles.tokenRow}>
+              <input
+                id="settings-hf-token"
+                type="text"
+                value={hfToken}
+                onChange={e => handleTokenChange(e.target.value)}
+                placeholder="hf_xxxxxxxxxxxxxxxxxxxx"
+                className={styles.textInput}
+                aria-label="Hugging Face API token"
+                autoComplete="off"
+                style={{ WebkitTextSecurity: hfReveal ? 'none' : 'disc' } as React.CSSProperties}
+              />
+              <Button
+                variant="control"
+                aria-label={hfReveal ? 'Hide token' : 'Show token'}
+                onClick={() => setHfReveal(r => !r)}
+                icon={hfReveal ? <EyeSlashIcon /> : <EyeIcon />}
+              />
+            </div>
+            <div className={styles.helperText}>
+              <a
+                href="https://huggingface.co/settings/tokens"
+                target="_blank"
+                rel="noopener noreferrer"
+                className={styles.link}
+              >
+                Get a token at huggingface.co →
+              </a>
+            </div>
+          </div>
+        </div>
+
+        {/* ── Inference backend ── */}
+        <div className={styles.section}>
+          <div className={styles.sectionHead}>
+            <div>
+              <div className={styles.sectionTitle}>Inference backend</div>
+              <div className={styles.sectionDesc}>
+                Serving framework targeted when generating configuration recommendations.
+              </div>
+            </div>
+            {backendSaved && (
+              <Label color="green" icon={<CheckCircleIcon />}>Saved</Label>
+            )}
+          </div>
+          <div className={styles.fieldWrap}>
+            <div className={styles.backendRow}>
+              <div className={styles.backendField}>
+                <label className={styles.fieldLabel} htmlFor="settings-backend">Backend</label>
+                <select
+                  id="settings-backend"
+                  value={inferenceBackend}
+                  onChange={e => handleBackendChange(e.target.value as InferenceBackend)}
+                  className={styles.selectInput}
+                >
+                  {BACKENDS.map(b => (
+                    <option key={b.value} value={b.value}>{b.label}</option>
+                  ))}
+                </select>
+              </div>
+              <div className={styles.versionField}>
+                <label className={styles.fieldLabel} htmlFor="settings-backend-version">Version</label>
+                <input
+                  id="settings-backend-version"
+                  type="text"
+                  value={backendVersion}
+                  onChange={e => handleVersionChange(e.target.value)}
+                  className={styles.textInput}
+                  placeholder={getAppConfig().backendVersions[inferenceBackend] ?? ''}
+                  spellCheck={false}
+                  autoComplete="off"
+                />
+              </div>
+            </div>
+            {selectedBackend && (
+              <div className={styles.helperText}>{selectedBackend.description}</div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/settings/Settings.tsx
+++ b/app/settings/Settings.tsx
@@ -9,7 +9,7 @@ import { useAicCatalog } from '@/lib/hooks/useAicCatalog';
 import { fetchModelConfig } from '@/lib/huggingface/fetch-config';
 import styles from './Settings.module.css';
 
-type ModelStatus = 'idle' | 'catalog' | 'fetching' | 'fetched' | 'error';
+type ModelStatus = 'idle' | 'supported' | 'catalog' | 'fetching' | 'fetched' | 'error';
 
 const BACKENDS: { value: InferenceBackend; label: string; description: string }[] = [
   { value: 'vllm', label: 'vLLM', description: 'Open-source LLM inference engine; default for most deployments.' },
@@ -53,6 +53,7 @@ export function Settings() {
     if (catalogLoading) { setModelStatus('idle'); return; }
     if (!localModel || !localModel.includes('/')) { setModelStatus('idle'); return; }
     const timer = setTimeout(() => {
+      if (getAppConfig().supportedModels.includes(localModel)) { setModelStatus('supported'); return; }
       const inCatalog = modelOptions.includes(localModel);
       if (inCatalog) { setModelStatus('catalog'); return; }
       setModelStatus('fetching');
@@ -61,7 +62,7 @@ export function Settings() {
       });
     }, 500);
     return () => clearTimeout(timer);
-  }, [localModel, hfToken, modelOptions, catalogLoading]);
+  }, [localModel, hfToken, modelOptions, catalogLoading, hydrated]);
 
   const handleTokenChange = (v: string) => {
     setHfToken(v);
@@ -128,14 +129,17 @@ export function Settings() {
                 {modelOptions.map(m => <option key={m} value={m} />)}
               </datalist>
               <div className={styles.autoChipWrapper}>
+                {modelStatus === 'supported' && (
+                  <Label color="blue" isCompact icon={<CheckCircleIcon />}>Supported</Label>
+                )}
                 {modelStatus === 'catalog' && (
                   <Label color="green" isCompact icon={<CheckCircleIcon />}>In catalog</Label>
                 )}
                 {modelStatus === 'fetching' && (
-                  <Label color="blue" isCompact>Checking…</Label>
+                  <Label color="grey" isCompact>Checking…</Label>
                 )}
                 {modelStatus === 'fetched' && (
-                  <Label color="cyan" isCompact icon={<CheckCircleIcon />}>From HuggingFace</Label>
+                  <Label color="gold" isCompact icon={<CheckCircleIcon />}>From HuggingFace</Label>
                 )}
                 {modelStatus === 'error' && (
                   <Label color="red" isCompact icon={<ExclamationTriangleIcon />}>Not found</Label>

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import { PageSection } from '@patternfly/react-core';
+import { Settings } from './Settings';
+
+export default function Page() {
+  return (
+    <PageSection
+      padding={{ default: 'noPadding' }}
+      style={{
+        backgroundColor: 'var(--gc-bg-2, #f5f5f5)',
+        minHeight: '100vh',
+      }}
+    >
+      <Settings />
+    </PageSection>
+  );
+}

--- a/components/layout/AppShell.tsx
+++ b/components/layout/AppShell.tsx
@@ -207,8 +207,8 @@ export function AppShell({ children }: { children: React.ReactNode }) {
             <NavItemWithIcon
               icon={CogIcon}
               label="Settings"
-              href="#"
-              isActive={false}
+              href="/settings"
+              isActive={pathname === "/settings"}
             />
           </NavList>
         </Nav>

--- a/contexts/SettingsContext.tsx
+++ b/contexts/SettingsContext.tsx
@@ -1,0 +1,111 @@
+'use client';
+
+import * as React from 'react';
+import { loadAppConfig, getAppConfig } from '@/lib/app-config';
+
+export type InferenceBackend = 'vllm' | 'tensorrt-llm' | 'sglang';
+
+const STORAGE_KEYS = {
+  defaultModel: 'settings_default_model',
+  hfToken: 'hf_token',
+  inferenceBackend: 'settings_inference_backend',
+  backendVersion: 'settings_backend_version',
+} as const;
+
+interface SettingsState {
+  hydrated: boolean;
+  defaultModel: string;
+  hfToken: string;
+  inferenceBackend: InferenceBackend;
+  backendVersion: string;
+  setDefaultModel: (v: string) => void;
+  setHfToken: (v: string) => void;
+  setInferenceBackend: (v: InferenceBackend) => void;
+  setBackendVersion: (v: string) => void;
+}
+
+const SettingsContext = React.createContext<SettingsState>({
+  hydrated: false,
+  defaultModel: '',
+  hfToken: '',
+  inferenceBackend: 'vllm',
+  backendVersion: '',
+  setDefaultModel: () => {},
+  setHfToken: () => {},
+  setInferenceBackend: () => {},
+  setBackendVersion: () => {},
+});
+
+export function SettingsProvider({ children }: { children: React.ReactNode }) {
+  const [hydrated, setHydrated] = React.useState(false);
+  const [defaultModel, setDefaultModelState] = React.useState('');
+  const [hfToken, setHfTokenState] = React.useState('');
+  const [inferenceBackend, setInferenceBackendState] = React.useState<InferenceBackend>('vllm');
+  const [backendVersion, setBackendVersionState] = React.useState('');
+
+  React.useEffect(() => {
+    async function init() {
+      // Load config.json first — gives us the defaults to fall back to
+      const config = await loadAppConfig();
+
+      // localStorage overrides config; null means "never saved by user" so use config default
+      const savedModel = localStorage.getItem(STORAGE_KEYS.defaultModel);
+      setDefaultModelState(savedModel !== null ? savedModel : config.defaultModel);
+
+      setHfTokenState(localStorage.getItem(STORAGE_KEYS.hfToken) ?? '');
+
+      const savedBackend = localStorage.getItem(STORAGE_KEYS.inferenceBackend) as InferenceBackend | null;
+      const activeBackend: InferenceBackend = savedBackend ?? config.defaultBackend as InferenceBackend;
+      setInferenceBackendState(activeBackend);
+
+      const savedVersion = localStorage.getItem(STORAGE_KEYS.backendVersion);
+      setBackendVersionState(savedVersion !== null ? savedVersion : (config.backendVersions[activeBackend] ?? ''));
+
+      setHydrated(true);
+    }
+    init();
+  }, []);
+
+  const setDefaultModel = React.useCallback((v: string) => {
+    setDefaultModelState(v);
+    localStorage.setItem(STORAGE_KEYS.defaultModel, v);
+  }, []);
+
+  const setHfToken = React.useCallback((v: string) => {
+    setHfTokenState(v);
+    if (v) {
+      localStorage.setItem(STORAGE_KEYS.hfToken, v);
+    } else {
+      localStorage.removeItem(STORAGE_KEYS.hfToken);
+    }
+  }, []);
+
+  const setInferenceBackend = React.useCallback((v: InferenceBackend) => {
+    setInferenceBackendState(v);
+    localStorage.setItem(STORAGE_KEYS.inferenceBackend, v);
+    // Reset version to config default for the new backend
+    const defaultVersion = getAppConfig().backendVersions[v] ?? '';
+    setBackendVersionState(defaultVersion);
+    localStorage.setItem(STORAGE_KEYS.backendVersion, defaultVersion);
+  }, []);
+
+  const setBackendVersion = React.useCallback((v: string) => {
+    setBackendVersionState(v);
+    localStorage.setItem(STORAGE_KEYS.backendVersion, v);
+  }, []);
+
+  const value = React.useMemo<SettingsState>(
+    () => ({ hydrated, defaultModel, hfToken, inferenceBackend, backendVersion, setDefaultModel, setHfToken, setInferenceBackend, setBackendVersion }),
+    [hydrated, defaultModel, hfToken, inferenceBackend, backendVersion, setDefaultModel, setHfToken, setInferenceBackend, setBackendVersion],
+  );
+
+  return (
+    <SettingsContext.Provider value={value}>
+      {children}
+    </SettingsContext.Provider>
+  );
+}
+
+export function useSettings(): SettingsState {
+  return React.useContext(SettingsContext);
+}

--- a/lib/app-config.ts
+++ b/lib/app-config.ts
@@ -2,6 +2,8 @@ export interface AppConfig {
   defaultModel: string;
   defaultBackend: string;
   backendVersions: Record<string, string>;
+  supportedModels: string[];
+  suggestedModelNames: string[];
 }
 
 // Hardcoded fallback — used if /config.json fails to load
@@ -13,6 +15,8 @@ const FALLBACK: AppConfig = {
     'tensorrt-llm': '11.2',
     'sglang': '0.5.17',
   },
+  supportedModels: [],
+  suggestedModelNames: [],
 };
 
 let cached: AppConfig | null = null;
@@ -27,6 +31,8 @@ export async function loadAppConfig(): Promise<AppConfig> {
       defaultModel: data.defaultModel ?? FALLBACK.defaultModel,
       defaultBackend: data.defaultBackend ?? FALLBACK.defaultBackend,
       backendVersions: data.backendVersions ?? FALLBACK.backendVersions,
+      supportedModels: data.supportedModels ?? FALLBACK.supportedModels,
+      suggestedModelNames: data.suggestedModelNames ?? FALLBACK.suggestedModelNames,
     };
   } catch {
     cached = FALLBACK;

--- a/lib/app-config.ts
+++ b/lib/app-config.ts
@@ -1,0 +1,40 @@
+export interface AppConfig {
+  defaultModel: string;
+  defaultBackend: string;
+  backendVersions: Record<string, string>;
+}
+
+// Hardcoded fallback — used if /config.json fails to load
+const FALLBACK: AppConfig = {
+  defaultModel: 'Qwen/Qwen3-32B',
+  defaultBackend: 'vllm',
+  backendVersions: {
+    'vllm': '0.24.0',
+    'tensorrt-llm': '11.2',
+    'sglang': '0.5.17',
+  },
+};
+
+let cached: AppConfig | null = null;
+
+export async function loadAppConfig(): Promise<AppConfig> {
+  if (cached) return cached;
+  try {
+    const res = await fetch('/config.json');
+    if (!res.ok) throw new Error(`config.json fetch failed (${res.status})`);
+    const data = await res.json() as Partial<AppConfig>;
+    cached = {
+      defaultModel: data.defaultModel ?? FALLBACK.defaultModel,
+      defaultBackend: data.defaultBackend ?? FALLBACK.defaultBackend,
+      backendVersions: data.backendVersions ?? FALLBACK.backendVersions,
+    };
+  } catch {
+    cached = FALLBACK;
+  }
+  return cached;
+}
+
+// Synchronous read after loadAppConfig() has been awaited — returns fallback until then
+export function getAppConfig(): AppConfig {
+  return cached ?? FALLBACK;
+}

--- a/public/config.json
+++ b/public/config.json
@@ -1,0 +1,9 @@
+{
+  "defaultModel": "Qwen/Qwen3-32B",
+  "defaultBackend": "vllm",
+  "backendVersions": {
+    "vllm": "0.24.0",
+    "tensorrt-llm": "11.2",
+    "sglang": "0.5.17"
+  }
+}

--- a/public/config.json
+++ b/public/config.json
@@ -5,5 +5,26 @@
     "vllm": "0.24.0",
     "tensorrt-llm": "11.2",
     "sglang": "0.5.17"
-  }
+  },
+  "suggestedModelNames": ["Gemma 4", "Nemotron Super", "DeepSeek V4", "Kimi K3"],
+  "supportedModels": [
+    "google/gemma-4-26B-A4B",
+    "nvidia/Llama-3_3-Nemotron-Super-49B-v1",
+    "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4",
+    "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16",
+    "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-FP8",
+    "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4",
+    "openai/gpt-oss-120b",
+    "openai/gpt-oss-20b",
+    "zai-org/GLM-5.2",
+    "zai-org/GLM-5.2-FP8",
+    "nvidia/GLM-5.2-NVFP4",
+    "deepseek-ai/DeepSeek-V4-Flash",
+    "sgl-project/DeepSeek-V4-Flash-FP8",
+    "deepseek-ai/DeepSeek-V4-Pro",
+    "sgl-project/DeepSeek-V4-Pro-FP8",
+    "moonshotai/Kimi-K2.5",
+    "nvidia/Kimi-K2.5-NVFP4",
+    "moonshotai/Kimi-K3"
+  ]
 }


### PR DESCRIPTION
## Summary

- Adds `/settings` page with AIC model autocomplete, HF token field (CSS masking, no browser credential prompts), and inference backend + version dropdowns
- `SettingsContext` provides hydrated defaults to all tools — localStorage overrides `config.json` overrides hardcoded fallback
- `public/config.json` externalises default model, backend, and backend version strings — update without touching TypeScript
- `lib/app-config.ts` fetches and caches config at startup with graceful fallback
- Quick Estimate, Calculator, and KV Cache Calculator all initialise model/backend/version from settings after context hydration
- HF token input removed from tool pages; replaced with contextual "Gated model? Add your HF token in Settings →" hint that links directly to the settings page

## Test plan

- [ ] Visit `/settings` — confirm model autocomplete shows AIC catalog, "In catalog" chip appears, backend/version dropdowns save and show "Saved" badge
- [ ] Set a default model in Settings, navigate to Quick Estimate and Calculator — confirm model field is pre-filled
- [ ] Set HF token in Settings — confirm "🔑 HF token active" appears on tool pages; clear it and confirm the Settings link appears instead
- [ ] Change backend in Settings — confirm version resets to the correct default from `config.json`
- [ ] Edit `public/config.json` defaults — confirm changes are picked up on next page load without code changes
- [ ] Confirm no browser "save password" prompts on any page

Related to #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)