### PR TITLE
feat: validated-only model toggle, shared input components, hide costings

### DIFF
--- a/app/calculator/AdvancedEstimate.tsx
+++ b/app/calculator/AdvancedEstimate.tsx
@@ -18,6 +18,8 @@ import { useGpuSizer } from '@/contexts/GpuSizerContext';
 import { useAicCatalog } from '@/lib/hooks/useAicCatalog';
 import { useSettings } from '@/contexts/SettingsContext';
 import { getAppConfig } from '@/lib/app-config';
+import { ModelInput } from '@/components/ui/ModelInput';
+import { GpuSystemInput } from '@/components/ui/GpuSystemInput';
 
 function modelSuggestions(): string {
   const names = getAppConfig().suggestedModelNames;
@@ -236,79 +238,19 @@ export default function AdvancedEstimate() {
         {/* Model + GPU row */}
         <div className={styles.inputGrid}>
           <div>
-            <label className={styles.fieldLabel}>
-              Model — Hugging Face ID
-              <StatusChip status={modelStatus} />
-            </label>
-            <div className={styles.modelInputWrapper}>
-              <input
-                type="text"
-                className={styles.modelInput}
-                value={model}
-                onChange={e => setModel(e.target.value)}
-                list="model-options"
-                placeholder="e.g. meta-llama/Llama-3.1-70B-Instruct"
-                spellCheck={false}
-                autoComplete="off"
-              />
-              <datalist id="model-options">
-                {MODEL_OPTIONS.map(m => <option key={m} value={m} />)}
-              </datalist>
-              <div className={styles.autoChipWrapper}>
-                {modelStatus === 'supported' && (
-                  <Label color="blue" isCompact icon={<CheckCircleIcon />}>Supported</Label>
-                )}
-                {modelStatus === 'catalog' && (
-                  <Label color="green" isCompact icon={<CheckCircleIcon />}>In catalog</Label>
-                )}
-                {modelStatus === 'fetching' && (
-                  <Label color="grey" isCompact>Checking...</Label>
-                )}
-                {modelStatus === 'fetched' && (
-                  <Label color="gold" isCompact icon={<CheckCircleIcon />}>From HuggingFace</Label>
-                )}
-                {modelStatus === 'error' && (
-                  <Label color="red" isCompact icon={<ExclamationTriangleIcon />}>Not found</Label>
-                )}
-              </div>
-            </div>
-            <div className={styles.helperText}>
-              Supported: {modelSuggestions()} — type to autocomplete
-              {hfToken ? (
-                <span style={{ marginLeft: '8px', color: '#0066cc', fontWeight: 500 }}>🔑 HF token active</span>
-              ) : (
-                <span style={{ marginLeft: '8px' }}>
-                  Gated model?{' '}
-                  <a href="/settings" style={{ color: '#0066cc' }}>Add your HF token in Settings →</a>
-                </span>
-              )}
-            </div>
+            <ModelInput
+              id="adv-model"
+              model={model}
+              onChange={setModel}
+              modelOptions={aicModels}
+              isLoading={catalogLoading}
+              hfToken={hfToken}
+              status={modelStatus}
+              placeholder="e.g. meta-llama/Llama-3.1-70B-Instruct"
+            />
           </div>
 
-          <div>
-            <label className={styles.fieldLabel}>GPU system</label>
-            <select
-              className={styles.gpuSelect}
-              value={gpuSystem}
-              onChange={e => setGpuSystem(e.target.value)}
-            >
-              {aicGpus.length === 0
-                ? <option value={gpuSystem} disabled>Loading GPU catalog…</option>
-                : aicGpus.map(g => (
-                    <option key={g.systemId} value={g.systemId}>
-                      {g.label}{g.vramGb ? ` — ${g.vramGb} GB` : ''}
-                    </option>
-                  ))
-              }
-            </select>
-            {currentGpuOption && (
-              <div className={styles.helperText}>
-                {currentGpuOption.vramGb != null && <>{currentGpuOption.vramGb} GB</>}
-                {currentGpuOption.bandwidthTbps != null && <> · {currentGpuOption.bandwidthTbps} TB/s</>}
-                {currentGpuOption.tflopsBf16 != null && <> · {currentGpuOption.tflopsBf16.toFixed(0)} TFLOPS</>}
-              </div>
-            )}
-          </div>
+          <GpuSystemInput id="adv-gpu" value={gpuSystem} onChange={setGpuSystem} gpuOptions={aicGpus} />
         </div>
 
         {/* Calculate button */}

--- a/app/kv-cache/KvCacheCalc.module.css
+++ b/app/kv-cache/KvCacheCalc.module.css
@@ -55,15 +55,14 @@
 }
 .inputRow {
   display: grid;
-  grid-template-columns: minmax(280px, 1.6fr) minmax(220px, 1fr) auto;
+  grid-template-columns: 1.6fr 1fr;
   gap: 16px;
-  align-items: end;
 }
 @media (max-width: 700px) {
   .inputRow { grid-template-columns: 1fr; }
 }
 
-.field { display: flex; flex-direction: column; gap: 6px; }
+.field { display: flex; flex-direction: column; }
 .fieldLabel {
   font-family: var(--mono);
   font-size: 12px;
@@ -71,6 +70,8 @@
   letter-spacing: 0.06em;
   text-transform: uppercase;
   color: var(--t2);
+  line-height: 1.2;
+  margin-bottom: 6px;
 }
 
 .modelInputWrapper {

--- a/app/kv-cache/KvCacheCalc.tsx
+++ b/app/kv-cache/KvCacheCalc.tsx
@@ -8,6 +8,8 @@ import { useCountUp } from '@/app/performance-estimate/quickEstimateHelpers'
 import { useAicCatalog } from '@/lib/hooks/useAicCatalog'
 import { useSettings, type InferenceBackend } from '@/contexts/SettingsContext'
 import { getAppConfig } from '@/lib/app-config'
+import { ModelInput, type ModelStatus } from '@/components/ui/ModelInput'
+import { GpuSystemInput } from '@/components/ui/GpuSystemInput'
 import type { KvCacheCalcResult } from '@/lib/api/kv-cache-calc'
 import styles from './KvCacheCalc.module.css'
 
@@ -62,6 +64,11 @@ export default function KvCacheCalc() {
   const [debugDuration, setDebugDuration] = React.useState<number | null>(null)
 
   const catalogMatch = MODEL_OPTIONS.includes(model)
+  const kvModelStatus: ModelStatus = getAppConfig().supportedModels.includes(model)
+    ? 'supported'
+    : catalogMatch ? 'catalog'
+    : catalogLoading ? 'fetching'
+    : model ? 'idle' : 'idle'
 
   async function handleCalculate() {
     setLoading(true)
@@ -140,57 +147,20 @@ export default function KvCacheCalc() {
       <div className={styles.inputCard}>
         <div className={styles.inputRow}>
           <div className={styles.field}>
-            <label htmlFor="kv-model" className={styles.fieldLabel}>Model — Hugging Face ID</label>
-            <div className={styles.modelInputWrapper}>
-              <input
-                type="text"
-                id="kv-model"
-                list="kv-models"
-                value={model}
-                onChange={e => setModel(e.target.value)}
-                placeholder="Type model name or select from dropdown..."
-                className={styles.modelInput}
-                spellCheck={false}
-                autoComplete="off"
-              />
-              <datalist id="kv-models">
-                {MODEL_OPTIONS.map(m => <option key={m} value={m} />)}
-              </datalist>
-              {model && (
-                <span className={styles.modelChip}>
-                  {getAppConfig().supportedModels.includes(model) ? (
-                    <Label color="blue" isCompact icon={<CheckCircleIcon />}>Supported</Label>
-                  ) : catalogMatch ? (
-                    <Label color="green" isCompact icon={<CheckCircleIcon />}>In catalog</Label>
-                  ) : catalogLoading ? (
-                    <Label color="grey" isCompact>Loading...</Label>
-                  ) : (
-                    <Label color="grey" isCompact>Custom model</Label>
-                  )}
-                </span>
-              )}
-            </div>
+            <ModelInput
+              id="kv-model"
+              model={model}
+              onChange={setModel}
+              modelOptions={aicModels}
+              isLoading={catalogLoading}
+              status={kvModelStatus}
+            />
           </div>
 
-          <div className={styles.field}>
-            <label htmlFor="kv-gpu" className={styles.fieldLabel}>GPU system</label>
-            <select
-              id="kv-gpu"
-              value={system}
-              onChange={e => setSystem(e.target.value)}
-              className={styles.gpuSelect}
-            >
-              {aicGpus.length === 0
-                ? <option value={system} disabled>Loading GPU catalog…</option>
-                : aicGpus.map(g => (
-                    <option key={g.systemId} value={g.systemId}>
-                      {g.label}{g.vramGb ? ` — ${g.vramGb} GB` : ''}
-                    </option>
-                  ))
-              }
-            </select>
-          </div>
+          <GpuSystemInput id="kv-gpu" value={system} onChange={setSystem} gpuOptions={aicGpus} />
+        </div>
 
+        <div style={{ display: 'flex', justifyContent: 'flex-end', marginTop: 16 }}>
           <button
             type="button"
             className={styles.calcBtn}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -50,20 +50,21 @@ const tools = [
     href: "/performance-estimate",
     icon: <BoltIcon />,
   },
-  {
-    title: "Hybrid Savings",
-    description:
-      "Model cost savings between cloud, on-premise, and hybrid GPU deployment strategies.",
-    href: "/hybrid-savings",
-    icon: <MigrationIcon />,
-  },
-  {
-    title: "Routing economics",
-    description:
-      "Analyze request routing between model tiers to optimize cost vs quality tradeoffs.",
-    href: "/routing",
-    icon: <RouteIcon />,
-  },
+  // Hidden pending aicostings API
+  // {
+  //   title: "Hybrid Savings",
+  //   description:
+  //     "Model cost savings between cloud, on-premise, and hybrid GPU deployment strategies.",
+  //   href: "/hybrid-savings",
+  //   icon: <MigrationIcon />,
+  // },
+  // {
+  //   title: "Routing economics",
+  //   description:
+  //     "Analyze request routing between model tiers to optimize cost vs quality tradeoffs.",
+  //   href: "/routing",
+  //   icon: <RouteIcon />,
+  // },
 ];
 
 export default function HomePage() {

--- a/app/performance-estimate/PerformanceEstimate.module.css
+++ b/app/performance-estimate/PerformanceEstimate.module.css
@@ -66,24 +66,10 @@
 .inputCard { padding: 18px 20px; margin-bottom: 16px; }
 .inputRow {
   display: grid;
-  grid-template-columns: minmax(280px, 1.6fr) minmax(220px, 1fr) auto;
-  grid-template-rows: auto auto auto;
-  column-gap: 16px;
-  row-gap: 6px;
-  align-items: center;
+  grid-template-columns: 1.6fr 1fr;
+  gap: 16px;
 }
-.field {
-  display: contents;
-}
-/* Row 1: Labels */
-.field:nth-child(1) .fieldLabel {
-  grid-column: 1;
-  grid-row: 1;
-}
-.field:nth-child(2) .fieldLabel {
-  grid-column: 2;
-  grid-row: 1;
-}
+@media (max-width: 700px) { .inputRow { grid-template-columns: 1fr; } }
 
 .fieldLabel {
   font-family: var(--mono);
@@ -96,22 +82,9 @@
   align-items: center;
   gap: 6px;
   line-height: 1.2;
+  margin-bottom: 6px;
 }
 
-/* Row 2: Controls */
-.field:nth-child(1) .modelInputWrapper {
-  grid-column: 1;
-  grid-row: 2;
-}
-.field:nth-child(2) .gpuSelect {
-  grid-column: 2;
-  grid-row: 2;
-}
-.calcBtnWrap {
-  grid-column: 3;
-  grid-row: 2;
-  align-self: center;
-}
 
 .modelInputWrapper {
   position: relative;
@@ -155,12 +128,6 @@
   box-sizing: border-box !important;
   display: flex !important;
   align-items: center !important;
-}
-
-/* Row 3: Helper text */
-.field:nth-child(1) .helperText {
-  grid-column: 1;
-  grid-row: 3;
 }
 
 .helperText {

--- a/app/performance-estimate/PerformanceEstimate.tsx
+++ b/app/performance-estimate/PerformanceEstimate.tsx
@@ -29,6 +29,8 @@ import { fetchModelConfig, type HFModelConfig } from '@/lib/huggingface/fetch-co
 import { saveEstimate, getSavedEstimateCount } from '@/lib/saved-estimates';
 import { fetchEstimateAsInferenceResult, EstimateError } from '@/lib/api/estimate-adapter';
 import { InfoStrip, InfoStripAction } from '@/components/ui/InfoStrip';
+import { ModelInput, type ModelStatus } from '@/components/ui/ModelInput';
+import { GpuSystemInput } from '@/components/ui/GpuSystemInput';
 import { useAicCatalog } from '@/lib/hooks/useAicCatalog';
 import { GpuChipLoader } from '@/components/GpuChipLoader/GpuChipLoader';
 import { useSettings } from '@/contexts/SettingsContext';
@@ -77,8 +79,6 @@ export default function QuickEstimate() {
   const { hydrated, hfToken, defaultModel: settingsDefaultModel, inferenceBackend, backendVersion } = useSettings();
   const { gpuOptions: aicGpus, modelOptions: aicModels, modelSpecs, isLoading: catalogLoading } = useAicCatalog();
 
-  const MODEL_OPTIONS = aicModels;
-
   const [model, setModel] = React.useState('');
   const [gpu, setGpu] = React.useState(() => getAppConfig().defaultSystem);
 
@@ -113,6 +113,18 @@ export default function QuickEstimate() {
   const [isFetchingConfig, setIsFetchingConfig] = React.useState(false);
   const [isUsingFallback, setIsUsingFallback] = React.useState(false);
   const [fallbackReason, setFallbackReason] = React.useState<string>('');
+
+  const modelStatus: ModelStatus = getAppConfig().supportedModels.includes(model)
+    ? 'supported'
+    : aicModels.includes(model)
+    ? 'catalog'
+    : isFetchingConfig || catalogLoading
+    ? 'fetching'
+    : hfConfig
+    ? 'fetched'
+    : testError
+    ? 'error'
+    : 'idle';
 
   // Collapsible state for "Why this GPU count?" card
   const [whyGpuExpanded, setWhyGpuExpanded] = React.useState(false);
@@ -161,7 +173,7 @@ export default function QuickEstimate() {
     setFallbackReason('');
 
     // Skip HF fetch for supported and catalog models — we know they work
-    if (getAppConfig().supportedModels.includes(model) || MODEL_OPTIONS.includes(model)) {
+    if (getAppConfig().supportedModels.includes(model) || aicModels.includes(model)) {
       setIsFetchingConfig(false);
       return;
     }
@@ -862,93 +874,32 @@ export default function QuickEstimate() {
       <div className={`${styles.card} ${styles.inputCard}`} data-tour="model">
         <div className={styles.inputRow}>
           {/* Column 1: Model field */}
-          <div className={styles.field}>
-            <label className={styles.fieldLabel} htmlFor="qe-model">
-              Model — Hugging Face ID
-              <InfoCircleIcon style={{ width: 12, height: 12, opacity: 0.7 }} />
-            </label>
-            <div className={styles.modelInputWrapper}>
-              <input
-                type="text"
-                id="qe-model"
-                list="qe-models"
-                value={model}
-                onChange={(e) => {
-                  console.log('📝 Model input changed to:', e.target.value);
-                  setModel(e.target.value);
-                }}
-                placeholder="Type model name or select from dropdown..."
-                aria-label="Model Hugging Face ID"
-                className={styles.modelInput}
-                spellCheck={false}
-                autoComplete="off"
-              />
-              <datalist id="qe-models">
-                {MODEL_OPTIONS.map((m) => <option key={m} value={m} />)}
-              </datalist>
-              <div className={styles.autoChipWrapper}>
-                {getAppConfig().supportedModels.includes(model) ? (
-                  <Label color="blue" icon={<CheckCircleIcon />}>Supported</Label>
-                ) : MODEL_OPTIONS.includes(model) ? (
-                  <Label color="green" icon={<CheckCircleIcon />}>In catalog</Label>
-                ) : isFetchingConfig || catalogLoading ? (
-                  <Label color="grey">Checking...</Label>
-                ) : hfConfig ? (
-                  <Label color="gold" icon={<CheckCircleIcon />}>From HuggingFace</Label>
-                ) : testError ? (
-                  <Label color="red" icon={<ExclamationTriangleIcon />}>Not found</Label>
-                ) : (
-                  <Label color="grey">Type to search...</Label>
-                )}
-              </div>
-            </div>
-            <div className={styles.helperText}>
-              Supported: {modelSuggestions()} — type to autocomplete
-              {hfToken ? (
-                <span style={{ marginLeft: '8px', color: '#0066cc', fontWeight: 500 }}>
-                  🔑 HF token active
-                </span>
-              ) : (
-                <span style={{ marginLeft: '8px' }}>
-                  Gated model?{' '}
-                  <a href="/settings" style={{ color: '#0066cc' }}>Add your HF token in Settings →</a>
-                </span>
-              )}
-            </div>
+          <div>
+            <ModelInput
+              id="qe-model"
+              model={model}
+              onChange={setModel}
+              modelOptions={aicModels}
+              isLoading={catalogLoading}
+              hfToken={hfToken}
+              status={modelStatus}
+            />
           </div>
 
           {/* Column 2: GPU target */}
-          <div className={styles.field}>
-            <label className={styles.fieldLabel} htmlFor="qe-gpu">GPU system</label>
-            <select
-              id="qe-gpu"
-              value={gpu}
-              onChange={(e) => setGpu(e.target.value)}
-              aria-label="GPU target"
-              className={styles.gpuSelect}
-            >
-              {aicGpus.length === 0
-                ? <option value={gpu} disabled>Loading GPU catalog…</option>
-                : aicGpus.map(g => (
-                    <option key={g.systemId} value={g.systemId}>
-                      {gpuOptionLabel(g.label, g.vramGb)}
-                    </option>
-                  ))
-              }
-            </select>
-          </div>
+          <GpuSystemInput id="qe-gpu" value={gpu} onChange={setGpu} gpuOptions={aicGpus} />
 
-          {/* Column 3: Calculate button */}
-          <div className={styles.calcBtnWrap}>
-            <Button
-              variant="primary"
-              size="lg"
-              onClick={() => { setTestResult(null); setCalcTrigger(t => t + 1); }}
-              isDisabled={isCalculating || !gpu || !model || catalogLoading}
-            >
-              {isCalculating ? 'Calculating...' : 'Calculate'}
-            </Button>
-          </div>
+        </div>
+
+        <div style={{ display: 'flex', justifyContent: 'flex-end', marginTop: 16 }}>
+          <Button
+            variant="primary"
+            size="lg"
+            onClick={() => { setTestResult(null); setCalcTrigger(t => t + 1); }}
+            isDisabled={isCalculating || !gpu || !model || catalogLoading}
+          >
+            {isCalculating ? 'Calculating...' : 'Calculate'}
+          </Button>
         </div>
 
       </div>

--- a/app/settings/Settings.tsx
+++ b/app/settings/Settings.tsx
@@ -28,6 +28,7 @@ export function Settings() {
   const [modelSaved, setModelSaved] = React.useState(false);
   const [tokenSaved, setTokenSaved] = React.useState(false);
   const [backendSaved, setBackendSaved] = React.useState(false);
+  const [validatedOpen, setValidatedOpen] = React.useState(false);
 
   // Sync local model input once context has loaded from localStorage
   const modelSynced = React.useRef(false);
@@ -122,6 +123,58 @@ export function Settings() {
               helperText="All tools use this model by default. Type to autocomplete from the AIC catalog."
             />
           </div>
+        </div>
+
+        {/* ── Validated models ── */}
+        <div className={styles.section}>
+          <div
+            className={styles.sectionHead}
+            style={{ cursor: 'pointer' }}
+            onClick={() => setValidatedOpen(o => !o)}
+          >
+            <div>
+              <div className={styles.sectionTitle}>
+                Validated models
+                <span style={{ fontSize: '11px', fontWeight: 400, marginLeft: '8px', color: '#6a6e73' }}>
+                  {validatedOpen ? '▲' : '▼'}
+                </span>
+              </div>
+              <div className={styles.sectionDesc}>
+                Models validated for use with the AIConfigurator sizing engine.
+              </div>
+            </div>
+            <Label color="blue" isCompact>{getAppConfig().supportedModels.length} models</Label>
+          </div>
+          {validatedOpen && (
+            <div className={styles.fieldWrap}>
+              <div style={{ display: 'flex', flexWrap: 'wrap', gap: '6px 8px' }}>
+                {getAppConfig().supportedModels.map(m => (
+                  <Label
+                    key={m}
+                    color="blue"
+                    isCompact
+                    style={{ cursor: 'pointer' }}
+                    onClick={() => {
+                      setLocalModel(m);
+                      setDefaultModel(m);
+                      setModelSaved(true);
+                      setTimeout(() => setModelSaved(false), 2000);
+                    }}
+                  >
+                    {m.split('/').pop()}
+                  </Label>
+                ))}
+              </div>
+              {getAppConfig().modelRequestUrl && (
+                <div style={{ marginTop: '12px', fontSize: '13px' }}>
+                  Don&apos;t see your model?{' '}
+                  <a href={getAppConfig().modelRequestUrl} target="_blank" rel="noopener" style={{ color: '#0066cc' }}>
+                    Request validation →
+                  </a>
+                </div>
+              )}
+            </div>
+          )}
         </div>
 
         {/* ── HF token ── */}

--- a/app/settings/Settings.tsx
+++ b/app/settings/Settings.tsx
@@ -5,6 +5,7 @@ import { Button, Label } from '@patternfly/react-core';
 import { EyeIcon, EyeSlashIcon, CheckCircleIcon, ExclamationTriangleIcon } from '@patternfly/react-icons';
 import { useSettings, type InferenceBackend } from '@/contexts/SettingsContext';
 import { getAppConfig } from '@/lib/app-config';
+import { ModelInput } from '@/components/ui/ModelInput';
 import { useAicCatalog } from '@/lib/hooks/useAicCatalog';
 import { fetchModelConfig } from '@/lib/huggingface/fetch-config';
 import styles from './Settings.module.css';
@@ -110,45 +111,16 @@ export function Settings() {
             )}
           </div>
           <div className={styles.fieldWrap}>
-            <label className={styles.fieldLabel} htmlFor="settings-model">
-              Hugging Face model ID
-            </label>
-            <div className={styles.modelInputWrapper}>
-              <input
-                id="settings-model"
-                type="text"
-                list="settings-model-options"
-                value={localModel}
-                onChange={e => setLocalModel(e.target.value)}
-                placeholder={catalogLoading ? 'Loading catalog…' : 'e.g. Qwen/Qwen3-32B'}
-                className={styles.modelInput}
-                spellCheck={false}
-                autoComplete="off"
-              />
-              <datalist id="settings-model-options">
-                {modelOptions.map(m => <option key={m} value={m} />)}
-              </datalist>
-              <div className={styles.autoChipWrapper}>
-                {modelStatus === 'supported' && (
-                  <Label color="blue" isCompact icon={<CheckCircleIcon />}>Supported</Label>
-                )}
-                {modelStatus === 'catalog' && (
-                  <Label color="green" isCompact icon={<CheckCircleIcon />}>In catalog</Label>
-                )}
-                {modelStatus === 'fetching' && (
-                  <Label color="grey" isCompact>Checking…</Label>
-                )}
-                {modelStatus === 'fetched' && (
-                  <Label color="gold" isCompact icon={<CheckCircleIcon />}>From HuggingFace</Label>
-                )}
-                {modelStatus === 'error' && (
-                  <Label color="red" isCompact icon={<ExclamationTriangleIcon />}>Not found</Label>
-                )}
-              </div>
-            </div>
-            <div className={styles.helperText}>
-              All tools use this model by default. Type to autocomplete from the AIC catalog.
-            </div>
+            <ModelInput
+              id="settings-model"
+              model={localModel}
+              onChange={setLocalModel}
+              modelOptions={modelOptions}
+              isLoading={catalogLoading}
+              status={modelStatus}
+              placeholder={catalogLoading ? 'Loading catalog…' : 'e.g. Qwen/Qwen3-32B'}
+              helperText="All tools use this model by default. Type to autocomplete from the AIC catalog."
+            />
           </div>
         </div>
 

--- a/components/layout/AppShell.tsx
+++ b/components/layout/AppShell.tsx
@@ -181,6 +181,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
               isActive={false}
             />}
 
+            {false && <>
             <div style={groupLabelStyle}>COSTINGS</div>
 
             <NavItemWithIcon
@@ -201,6 +202,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
               href="/routing"
               isActive={pathname === "/routing"}
             />
+            </>}
 
             <div style={groupLabelStyle}>SYSTEM</div>
 

--- a/components/ui/GpuSystemInput.module.css
+++ b/components/ui/GpuSystemInput.module.css
@@ -1,0 +1,40 @@
+.wrapper {
+  display: flex;
+  flex-direction: column;
+}
+
+.label {
+  font-size: 12px;
+  font-weight: 600;
+  font-family: var(--mono);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--t2, #3c3f42);
+  line-height: 1.2;
+  margin: 0 0 6px 0;
+}
+
+.select {
+  width: 100%;
+  height: 42px;
+  min-height: 42px;
+  border: 1px solid var(--line2, #d2d2d2);
+  border-radius: 4px;
+  padding: 7px 11px;
+  font-size: 14px;
+  font-family: var(--sans);
+  background: var(--bg, #fff);
+  box-sizing: border-box;
+  cursor: pointer;
+}
+
+.select:focus {
+  border-color: var(--blue, #0066cc);
+  outline: none;
+}
+
+.helperText {
+  font-size: 12px;
+  color: var(--gc-text-3, #6a6e73);
+  margin-top: 4px;
+}

--- a/components/ui/GpuSystemInput.tsx
+++ b/components/ui/GpuSystemInput.tsx
@@ -1,0 +1,44 @@
+'use client'
+
+import * as React from 'react'
+import type { GpuOption } from '@/lib/hooks/useAicCatalog'
+import styles from './GpuSystemInput.module.css'
+
+interface GpuSystemInputProps {
+  id: string
+  value: string
+  onChange: (value: string) => void
+  gpuOptions: GpuOption[]
+}
+
+export function GpuSystemInput({ id, value, onChange, gpuOptions }: GpuSystemInputProps) {
+  const current = gpuOptions.find(g => g.systemId === value)
+
+  return (
+    <div className={styles.wrapper}>
+      <label htmlFor={id} className={styles.label}>GPU system</label>
+      <select
+        id={id}
+        value={value}
+        onChange={e => onChange(e.target.value)}
+        className={styles.select}
+      >
+        {gpuOptions.length === 0
+          ? <option value={value} disabled>Loading GPU catalog…</option>
+          : gpuOptions.map(g => (
+              <option key={g.systemId} value={g.systemId}>
+                {g.label}{g.vramGb ? ` — ${g.vramGb} GB` : ''}
+              </option>
+            ))
+        }
+      </select>
+      {current && (
+        <div className={styles.helperText}>
+          {current.vramGb != null && <>{current.vramGb} GB</>}
+          {current.bandwidthTbps != null && <> · {current.bandwidthTbps} TB/s</>}
+          {current.tflopsBf16 != null && <> · {current.tflopsBf16.toFixed(0)} TFLOPS</>}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/components/ui/ModelInput.module.css
+++ b/components/ui/ModelInput.module.css
@@ -1,0 +1,99 @@
+.wrapper {
+  display: flex;
+  flex-direction: column;
+  position: relative;
+}
+
+.label {
+  font-size: 12px;
+  font-weight: 600;
+  font-family: var(--mono);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--t2, #3c3f42);
+  line-height: 1.2;
+  margin: 0 0 6px 0;
+}
+
+.toggle {
+  position: absolute;
+  top: -2px;
+  right: 10px;
+}
+
+.toggle :global(.pf-v5-c-switch__input:focus-visible ~ .pf-v5-c-switch__toggle) {
+  outline: none !important;
+  box-shadow: none !important;
+}
+
+.wrapper :global(.pf-v5-c-switch) {
+  --pf-v5-c-switch--Height: 18px !important;
+  --pf-v5-c-switch__toggle--Width: 32px !important;
+  --pf-v5-c-switch__toggle--Height: 16px !important;
+  --pf-v5-c-switch__toggle--BorderRadius: 9px !important;
+  font-size: 11px !important;
+}
+
+.wrapper :global(.pf-v5-c-switch__label) {
+  font-size: 11px !important;
+  font-weight: 500;
+}
+
+.wrapper :global(.pf-v5-c-switch__toggle) {
+  width: 32px !important;
+  height: 16px !important;
+}
+
+.wrapper :global(.pf-v5-c-switch__toggle::before) {
+  width: 12px !important;
+  height: 12px !important;
+}
+
+.inputWrapper {
+  position: relative;
+  width: 100%;
+}
+
+.input {
+  width: 100%;
+  height: 42px;
+  min-height: 42px;
+  border: 1px solid var(--line2, #d2d2d2);
+  border-radius: 4px;
+  padding: 7px 130px 7px 11px;
+  font-size: 14px;
+  font-family: var(--sans);
+  background: var(--bg, #fff);
+  box-sizing: border-box;
+}
+
+.input:focus {
+  border-color: var(--blue, #0066cc);
+  outline: none;
+}
+
+.badge {
+  position: absolute;
+  right: 8px;
+  top: 50%;
+  transform: translateY(-50%);
+  pointer-events: none;
+}
+
+.badge :global(.pf-v5-c-label) {
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.helperText {
+  font-size: 12px;
+  color: var(--gc-text-3, #6a6e73);
+}
+
+.requestLink {
+  color: var(--blue, #0066cc);
+}
+
+.requestLink:hover {
+  text-decoration: underline;
+}

--- a/components/ui/ModelInput.tsx
+++ b/components/ui/ModelInput.tsx
@@ -1,0 +1,121 @@
+'use client'
+
+import * as React from 'react'
+import { Label, Switch } from '@patternfly/react-core'
+import CheckCircleIcon from '@patternfly/react-icons/dist/esm/icons/check-circle-icon'
+import ExclamationTriangleIcon from '@patternfly/react-icons/dist/esm/icons/exclamation-triangle-icon'
+import { getAppConfig } from '@/lib/app-config'
+import styles from './ModelInput.module.css'
+
+export type ModelStatus = 'idle' | 'supported' | 'catalog' | 'fetching' | 'fetched' | 'error'
+
+interface ModelInputProps {
+  id: string
+  model: string
+  onChange: (value: string) => void
+  modelOptions: string[]
+  isLoading?: boolean
+  hfToken?: string
+  status?: ModelStatus
+  placeholder?: string
+  helperText?: React.ReactNode
+}
+
+function suggestedNames(): string {
+  const names = getAppConfig().suggestedModelNames
+  return names.length > 0 ? names.join(', ') : 'Nemotron, DeepSeek V4, Gemma 4, Kimi'
+}
+
+export function ModelInput({
+  id,
+  model,
+  onChange,
+  modelOptions,
+  isLoading,
+  hfToken,
+  status = 'idle',
+  placeholder = 'Type model name or select from dropdown...',
+  helperText,
+}: ModelInputProps) {
+  const [supportedOnly, setSupportedOnly] = React.useState(false)
+  const cfg = getAppConfig()
+  const supportedModels = cfg.supportedModels ?? []
+  const validatedModels = modelOptions.filter(m => supportedModels.includes(m))
+  const displayModels = supportedOnly ? validatedModels : modelOptions
+  const datalistId = `${id}-options`
+
+  const prevModel = React.useRef(model)
+
+  const handleToggle = (_: React.FormEvent, checked: boolean) => {
+    setSupportedOnly(checked)
+    if (checked) {
+      prevModel.current = model
+      if (!supportedModels.includes(model) && validatedModels.length > 0) {
+        onChange(validatedModels[0])
+      }
+    } else {
+      onChange(prevModel.current)
+    }
+  }
+
+  return (
+    <div className={styles.wrapper}>
+      <label className={styles.label} htmlFor={id}>
+        Model — Hugging Face ID
+      </label>
+      <div className={styles.toggle}>
+        <Switch
+          id={`${id}-validated-only`}
+          label="Validated only"
+          isChecked={supportedOnly}
+          onChange={handleToggle}
+          isReversed
+        />
+      </div>
+
+      <div className={styles.inputWrapper}>
+        <input
+          type="text"
+          id={id}
+          list={datalistId}
+          value={model}
+          onChange={e => onChange(e.target.value)}
+          placeholder={supportedOnly ? 'Select a validated model...' : placeholder}
+          className={styles.input}
+          spellCheck={false}
+          autoComplete="off"
+        />
+        <datalist id={datalistId}>
+          {displayModels.map(m => <option key={m} value={m} />)}
+        </datalist>
+        <div className={styles.badge}>
+          {status === 'supported' && <Label color="blue" isCompact icon={<CheckCircleIcon />}>Validated</Label>}
+          {status === 'catalog' && <Label color="green" isCompact icon={<CheckCircleIcon />}>In catalog</Label>}
+          {status === 'fetching' && <Label color="grey" isCompact>Checking...</Label>}
+          {status === 'fetched' && <Label color="gold" isCompact icon={<CheckCircleIcon />}>From HuggingFace</Label>}
+          {status === 'error' && <Label color="red" isCompact icon={<ExclamationTriangleIcon />}>Not found</Label>}
+          {status === 'idle' && isLoading && <Label color="grey" isCompact>Loading...</Label>}
+        </div>
+      </div>
+
+      <div className={styles.helperText}>
+        {helperText ?? (supportedOnly ? (
+            <span>Validated: {suggestedNames()}, ... — type to autocomplete</span>
+          ) : (
+            <>
+              <div>Validated: {suggestedNames()}, ... — type to autocomplete</div>
+              {model && !supportedModels.includes(model) && cfg.modelRequestUrl && (
+                <div>New model? <a href={cfg.modelRequestUrl + encodeURIComponent(model)} target="_blank" rel="noopener" className={styles.requestLink}>Request validation →</a></div>
+              )}
+              {hfToken ? (
+                <div style={{ color: '#0066cc', fontWeight: 500 }}>🔑 HF token active</div>
+              ) : (
+                <div>Gated model? <a href="/settings" className={styles.requestLink}>Add your HF token in Settings →</a></div>
+              )}
+            </>
+          )
+        )}
+      </div>
+    </div>
+  )
+}

--- a/lib/app-config.ts
+++ b/lib/app-config.ts
@@ -7,6 +7,7 @@ export interface AppConfig {
   backendVersions: Record<string, string>;
   supportedModels: string[];
   suggestedModelNames: string[];
+  modelRequestUrl: string;
 }
 
 // Hardcoded fallback — used if /config.json fails to load
@@ -23,6 +24,7 @@ const FALLBACK: AppConfig = {
   },
   supportedModels: [],
   suggestedModelNames: [],
+  modelRequestUrl: '',
 };
 
 let cached: AppConfig | null = null;
@@ -42,6 +44,7 @@ export async function loadAppConfig(): Promise<AppConfig> {
       backendVersions: data.backendVersions ?? FALLBACK.backendVersions,
       supportedModels: data.supportedModels ?? FALLBACK.supportedModels,
       suggestedModelNames: data.suggestedModelNames ?? FALLBACK.suggestedModelNames,
+      modelRequestUrl: data.modelRequestUrl ?? FALLBACK.modelRequestUrl,
     };
   } catch {
     cached = FALLBACK;

--- a/public/config.json
+++ b/public/config.json
@@ -29,5 +29,6 @@
     "moonshotai/Kimi-K2.5",
     "nvidia/Kimi-K2.5-NVFP4",
     "moonshotai/Kimi-K3"
-  ]
+  ],
+  "modelRequestUrl": "https://github.com/redhat-performance/configiq/issues/new?labels=model-request&title=[Model+Request]+"
 }


### PR DESCRIPTION
## Summary

- **Shared ModelInput component** — validated-only toggle, status badges, request validation link, consistent across all four pages
- **Shared GpuSystemInput component** — label, dropdown, specs helper text (GB, TB/s, TFLOPS), consistent across all three sizing pages
- **Collapsible validated model list on Settings** — blue chips, clickable to set default, request link
- **Config**: `modelRequestUrl` added to `public/config.json` and `AppConfig`
- **Hide COSTINGS** nav group and homepage cards pending aicostings API
- **Layout fixes**: Calculate button repositioned, grid alignment normalised across pages

Closes: #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)