### PR TITLE
fix: responsive sidebar toggle, GitHub link, remove WIP text

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -70,10 +70,7 @@ export default function HomePage() {
   return (
     <>
       <PageSection variant="light">
-        <div style={{ position: 'relative' }}>
-          <div style={{ position: 'absolute', top: 0, right: 0, fontSize: '0.875rem', color: '#6A6E73' }}>
-            Work in progress
-          </div>
+        <div>
           <TextContent>
             <Title headingLevel="h1" size="2xl">
               ConfigIQ

--- a/components/layout/AppShell.tsx
+++ b/components/layout/AppShell.tsx
@@ -5,13 +5,17 @@ import {
   Page,
   PageSidebar,
   PageSidebarBody,
+  PageToggleButton,
   Masthead,
   MastheadMain,
   MastheadBrand,
+  MastheadToggle,
   Nav,
   NavList,
   NavItem,
 } from "@patternfly/react-core";
+import BarsIcon from "@patternfly/react-icons/dist/esm/icons/bars-icon";
+import GithubIcon from "@patternfly/react-icons/dist/esm/icons/github-icon";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import {
@@ -68,6 +72,16 @@ export function AppShell({ children }: { children: React.ReactNode }) {
           </Link>
         </MastheadBrand>
       </MastheadMain>
+      <div style={{ marginLeft: 'auto', display: 'flex', alignItems: 'center', gap: 8 }}>
+        <a href="https://github.com/redhat-performance/configiq" target="_blank" rel="noopener" aria-label="GitHub repository" style={{ color: 'rgba(255,255,255,0.7)', display: 'flex', padding: 8 }}>
+          <GithubIcon style={{ width: 21, height: 21 }} />
+        </a>
+        <MastheadToggle>
+          <PageToggleButton variant="plain" aria-label="Navigation" id="nav-toggle">
+            <BarsIcon color="white" />
+          </PageToggleButton>
+        </MastheadToggle>
+      </div>
     </Masthead>
   );
 
@@ -240,6 +254,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
       header={masthead}
       sidebar={sidebar}
       isManagedSidebar
+      defaultManagedSidebarIsOpen={true}
       style={{ backgroundColor: "#f5f5f5" }}
     >
       {children}


### PR DESCRIPTION
## Summary

- **Responsive sidebar**: hamburger toggle in masthead (right side) for narrow viewports; sidebar stays open on wide screens via `defaultManagedSidebarIsOpen`
- **GitHub link**: icon in masthead linking to `redhat-performance/configiq`
- **Remove "Work in progress"** text from homepage

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GitHub repository and navigation toggle controls to the masthead.
  * The navigation sidebar now opens by default.

* **Bug Fixes**
  * Removed the “Work in progress” overlay from the homepage header.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->