### PR TITLE
fix: remove legacy route redirects

### DIFF
--- a/components/layout/AppShell.tsx
+++ b/components/layout/AppShell.tsx
@@ -9,6 +9,7 @@ import {
   Masthead,
   MastheadMain,
   MastheadBrand,
+  MastheadContent,
   MastheadToggle,
   Nav,
   NavList,
@@ -72,16 +73,16 @@ export function AppShell({ children }: { children: React.ReactNode }) {
           </Link>
         </MastheadBrand>
       </MastheadMain>
-      <div style={{ marginLeft: 'auto', display: 'flex', alignItems: 'center', gap: 8 }}>
-        <a href="https://github.com/redhat-performance/configiq" target="_blank" rel="noopener" aria-label="GitHub repository" style={{ color: 'rgba(255,255,255,0.7)', display: 'flex', padding: 8 }}>
+      <MastheadContent>
+        <a href="https://github.com/redhat-performance/configiq" target="_blank" rel="noopener" aria-label="GitHub repository" style={{ color: 'rgba(255,255,255,0.7)', display: 'flex', padding: 8, marginLeft: 'auto' }}>
           <GithubIcon style={{ width: 21, height: 21 }} />
         </a>
-        <MastheadToggle>
-          <PageToggleButton variant="plain" aria-label="Navigation" id="nav-toggle">
-            <BarsIcon color="white" />
-          </PageToggleButton>
-        </MastheadToggle>
-      </div>
+      </MastheadContent>
+      <MastheadToggle>
+        <PageToggleButton variant="plain" aria-label="Navigation" id="nav-toggle">
+          <BarsIcon color="white" />
+        </PageToggleButton>
+      </MastheadToggle>
     </Masthead>
   );
 

--- a/next.config.js
+++ b/next.config.js
@@ -8,25 +8,6 @@ const nextConfig = {
     "@patternfly/react-icons",
     "@patternfly/react-table",
   ],
-  async redirects() {
-    return [
-      {
-        source: '/quick-estimate',
-        destination: '/performance',
-        permanent: true,
-      },
-      {
-        source: '/performance-estimate',
-        destination: '/performance',
-        permanent: true,
-      },
-      {
-        source: '/calculator',
-        destination: '/recommend',
-        permanent: true,
-      },
-    ]
-  },
 };
 
 module.exports = nextConfig;


### PR DESCRIPTION
## Summary

Remove old 301 redirects from next.config.js (/quick-estimate, /performance-estimate, /calculator) — not needed for a new app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved header navigation layout by separating the menu toggle from the GitHub link.

* **Bug Fixes**
  * Removed outdated redirects for the quick estimate, performance estimate, calculator, and recommendation pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->