### PR TITLE
Fixing inputs for ConfigIQ, adding errors/grey-out for invalid inputs…

### DIFF
--- a/app/kv-cache/KvCacheCalc.module.css
+++ b/app/kv-cache/KvCacheCalc.module.css
@@ -222,6 +222,22 @@
   color: var(--t);
   background: #ffffff;
 }
+.paramInputInvalid {
+  width: 100%;
+  height: 40px;
+  border: 1px solid #b8bbbe;
+  border-radius: 4px;
+  padding: 6px 12px;
+  font-size: 14px;
+  font-family: var(--mono);
+  font-variant-numeric: tabular-nums;
+  color: var(--t);
+  background: #ffffff;
+  border-color: #c9190b;
+  box-shadow: 0 0 0 1px #c9190b;
+}
+
+
 .numberInput:focus { border-color: var(--blue); outline: none; }
 
 /* ---------- result tiles ---------- */

--- a/app/kv-cache/KvCacheCalc.tsx
+++ b/app/kv-cache/KvCacheCalc.tsx
@@ -73,7 +73,7 @@ export default function KvCacheCalc() {
   const invalidMaxBatchSize = maxBatchSizeInput === '' || parseInt(maxBatchSizeInput, 10) < 1;
   const invalidTpSize = tpSizeInput === '' || parseInt(tpSizeInput, 10) < 1;
   const invalidPpSize = ppSizeInput === '' || parseInt(ppSizeInput, 10) < 1;
-  const invalidMemFractionValue = memFractionValueInput === '' || parseFloat(memFractionValueInput) < 0 || parseFloat(memFractionValueInput) > 1;
+  const invalidMemFractionValue = memFractionValueInput === '' || !Number.isFinite(Number(memFractionValueInput)) || Number(memFractionValueInput) < 0 || Number(memFractionValueInput) > 1;
 
   const handleMaxNumTokensChange = (raw: string) => {
     const digits = raw.replace(/[^0-9]/g, '');
@@ -104,10 +104,10 @@ export default function KvCacheCalc() {
   };
 
   const handleMemFractionValueChange = (raw: string) => {
-    const digits = raw.replace(/[^0-9.]/g, '');
-    setMemFractionValueInput(digits);
-    const n = parseFloat(digits);
-    if (!isNaN(n) && n >= 0 && n <= 1) setMemFractionValue(n);
+    const cleaned = raw.replace(/[^0-9.]/g, '');
+    setMemFractionValueInput(cleaned);
+    const n = Number(cleaned);
+    if (Number.isFinite(n) && n >= 0 && n <= 1) setMemFractionValue(n);
   };
 
   const catalogMatch = MODEL_OPTIONS.includes(model)

--- a/app/kv-cache/KvCacheCalc.tsx
+++ b/app/kv-cache/KvCacheCalc.tsx
@@ -63,6 +63,53 @@ export default function KvCacheCalc() {
   const [debugStatus, setDebugStatus] = React.useState<number | null>(null)
   const [debugDuration, setDebugDuration] = React.useState<number | null>(null)
 
+  const [maxNumTokensInput, setMaxNumTokensInput] = React.useState('8192')
+  const [maxBatchSizeInput, setMaxBatchSizeInput] = React.useState('128')
+  const [tpSizeInput, setTpSizeInput] = React.useState('1')
+  const [ppSizeInput, setPpSizeInput] = React.useState('1')
+  const [memFractionValueInput, setMemFractionValueInput] = React.useState('1.0')
+
+  const invalidMaxNumTokens = maxNumTokensInput === '' || parseInt(maxNumTokensInput, 10) < 1;
+  const invalidMaxBatchSize = maxBatchSizeInput === '' || parseInt(maxBatchSizeInput, 10) < 1;
+  const invalidTpSize = tpSizeInput === '' || parseInt(tpSizeInput, 10) < 1;
+  const invalidPpSize = ppSizeInput === '' || parseInt(ppSizeInput, 10) < 1;
+  const invalidMemFractionValue = memFractionValueInput === '' || parseFloat(memFractionValueInput) < 0 || parseFloat(memFractionValueInput) > 1;
+
+  const handleMaxNumTokensChange = (raw: string) => {
+    const digits = raw.replace(/[^0-9]/g, '');
+    setMaxNumTokensInput(digits);
+    const n = parseInt(digits, 10);
+    if (!isNaN(n) && n >= 1) setMaxNumTokens(n);
+  };
+  
+  const handleMaxBatchSizeChange = (raw: string) => {
+    const digits = raw.replace(/[^0-9]/g, '');
+    setMaxBatchSizeInput(digits);
+    const n = parseInt(digits, 10);
+    if (!isNaN(n) && n >= 1) setMaxBatchSize(n);
+  };
+
+  const handleTpSizeChange = (raw: string) => {
+    const digits = raw.replace(/[^0-9]/g, '');
+    setTpSizeInput(digits);
+    const n = parseInt(digits, 10);
+    if (!isNaN(n) && n >= 1) setTpSize(n);
+  };
+
+  const handlePpSizeChange = (raw: string) => {
+    const digits = raw.replace(/[^0-9]/g, '');
+    setPpSizeInput(digits);
+    const n = parseInt(digits, 10);
+    if (!isNaN(n) && n >= 1) setPpSize(n);
+  };
+
+  const handleMemFractionValueChange = (raw: string) => {
+    const digits = raw.replace(/[^0-9.]/g, '');
+    setMemFractionValueInput(digits);
+    const n = parseFloat(digits);
+    if (!isNaN(n) && n >= 0 && n <= 1) setMemFractionValue(n);
+  };
+
   const catalogMatch = MODEL_OPTIONS.includes(model)
   const kvModelStatus: ModelStatus = getAppConfig().supportedModels.includes(model)
     ? 'supported'
@@ -164,8 +211,8 @@ export default function KvCacheCalc() {
           <button
             type="button"
             className={styles.calcBtn}
-            onClick={handleCalculate}
-            disabled={loading || !model.trim()}
+            onClick={handleCalculate} 
+            disabled={loading || !model.trim() || invalidMaxNumTokens || invalidMaxBatchSize || invalidTpSize || invalidPpSize || invalidMemFractionValue}
           >
             {loading ? 'Calculating…' : 'Calculate'}
           </button>
@@ -219,10 +266,10 @@ export default function KvCacheCalc() {
                 <input
                   type="number"
                   id="kv-tokens"
-                  value={maxNumTokens}
-                  onChange={e => setMaxNumTokens(parseInt(e.target.value, 10) || 0)}
+                  value={maxNumTokensInput}
+                  onChange={e => handleMaxNumTokensChange(e.target.value)}
                   min={1}
-                  className={styles.numberInput}
+                  className={invalidMaxNumTokens ? styles.paramInputInvalid : styles.numberInput}
                 />
               </div>
               <div className={styles.field}>
@@ -230,10 +277,10 @@ export default function KvCacheCalc() {
                 <input
                   type="number"
                   id="kv-batch"
-                  value={maxBatchSize}
-                  onChange={e => setMaxBatchSize(parseInt(e.target.value, 10) || 0)}
+                  value={maxBatchSizeInput}
+                  onChange={e => handleMaxBatchSizeChange(e.target.value)}
                   min={1}
-                  className={styles.numberInput}
+                  className={invalidMaxBatchSize ? styles.paramInputInvalid : styles.numberInput}
                 />
               </div>
             </div>
@@ -246,10 +293,10 @@ export default function KvCacheCalc() {
                 <input
                   type="number"
                   id="kv-tp"
-                  value={tpSize}
-                  onChange={e => setTpSize(parseInt(e.target.value, 10) || 1)}
+                  value={tpSizeInput}
+                  onChange={e => handleTpSizeChange(e.target.value)}
                   min={1}
-                  className={styles.numberInput}
+                  className={invalidTpSize ? styles.paramInputInvalid : styles.numberInput}
                 />
               </div>
               <div className={styles.field}>
@@ -257,10 +304,10 @@ export default function KvCacheCalc() {
                 <input
                   type="number"
                   id="kv-pp"
-                  value={ppSize}
-                  onChange={e => setPpSize(parseInt(e.target.value, 10) || 1)}
+                  value={ppSizeInput}
+                  onChange={e => handlePpSizeChange(e.target.value)}
                   min={1}
-                  className={styles.numberInput}
+                  className={invalidPpSize ? styles.paramInputInvalid : styles.numberInput}
                 />
               </div>
               <div className={styles.field}>
@@ -295,12 +342,12 @@ export default function KvCacheCalc() {
                 <input
                   type="number"
                   id="kv-mem-val"
-                  value={memFractionValue}
-                  onChange={e => setMemFractionValue(parseFloat(e.target.value) || 0)}
+                  value={memFractionValueInput}
+                  onChange={e => handleMemFractionValueChange(e.target.value)}
                   min={0}
                   max={1}
                   step={0.05}
-                  className={styles.numberInput}
+                  className={invalidMemFractionValue ? styles.paramInputInvalid : styles.numberInput}
                 />
               </div>
               <div className={styles.field}>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -26,7 +26,7 @@ const tools = [
     title: "Recommend sizing",
     description:
       "Find the optimal GPU configuration for a workload target using the AIConfigurator engine.",
-    href: "/calculator",
+    href: "/recommend",
     icon: <SlidersHIcon />,
   },
   {
@@ -47,7 +47,7 @@ const tools = [
     title: "Performance",
     description:
       "Estimate TTFT, TPOT, and throughput for your model and parallelism configuration.",
-    href: "/performance-estimate",
+    href: "/performance",
     icon: <BoltIcon />,
   },
   // Hidden pending aicostings API

--- a/app/performance/PerformanceEstimate.tsx
+++ b/app/performance/PerformanceEstimate.tsx
@@ -20,7 +20,6 @@ import LayerGroupIcon from '@patternfly/react-icons/dist/esm/icons/layer-group-i
 import InfoCircleIcon from '@patternfly/react-icons/dist/esm/icons/info-circle-icon';
 import EyeIcon from '@patternfly/react-icons/dist/esm/icons/eye-icon';
 import EyeSlashIcon from '@patternfly/react-icons/dist/esm/icons/eye-slash-icon';
-
 import styles from './PerformanceEstimate.module.css';
 import { Term, FlipTile, Sparkline, useCountUp } from './quickEstimateHelpers';
 import { ProductTour, type TourStep } from '@/components/ProductTour';
@@ -159,7 +158,45 @@ export default function QuickEstimate() {
   const [calcTrigger, setCalcTrigger] = React.useState(0);
   const [elapsed, setElapsed] = React.useState(0);
   const [testWeightPrecision, setTestWeightPrecision] = React.useState<'FP16' | 'FP8' | 'INT8' | 'INT4'>('FP16');
-  const [testKVCachePrecision, setTestKVCachePrecision] = React.useState<'FP16' | 'FP8'>('FP16');
+  const [testKVCachePrecision, setTestKVCachePrecision] = React.useState<'FP16' | 'FP8'>('FP16');44
+  
+  const [islInput, setIslInput] = React.useState('2048');
+  const [oslInput, setOslInput] = React.useState('128');
+  const [concurrentUsersInput, setConcurrentUsersInput] = React.useState('32');
+  const [tpSizeInput, setTpSizeInput] = React.useState('1');
+
+  const invalidISL = islInput === '' || parseInt(islInput, 10) < 1;
+  const invalidOSL = oslInput === '' || parseInt(oslInput, 10) < 1;
+  const invalidUsers = concurrentUsersInput === '' || parseInt(concurrentUsersInput, 10) < 1;
+  const invalidTpSize = tpSizeInput === '' || parseInt(tpSizeInput, 10) < 1;
+
+  const handleIslChange = (raw: string) => {
+    const digits = raw.replace(/[^0-9]/g, '');
+    setIslInput(digits);
+    const n = parseInt(digits, 10);
+    if (!isNaN(n) && n >= 1) setTestISL(n);
+  };
+
+  const handleOslChange = (raw: string) => {
+    const digits = raw.replace(/[^0-9]/g, '');
+    setOslInput(digits);
+    const n = parseInt(digits, 10);
+    if (!isNaN(n) && n >= 1) setTestOSL(n);
+  };
+
+  const handleConcurrentUsersChange = (raw: string) => {
+    const digits = raw.replace(/[^0-9]/g, '');
+    setConcurrentUsersInput(digits);
+    const n = parseInt(digits, 10);
+    if (!isNaN(n) && n >= 1) setTestConcurrentUsers(n);
+  };
+
+  const handleTpSizeChange = (raw: string) => {
+    const digits = raw.replace(/[^0-9]/g, '');
+    setTpSizeInput(digits);
+    const n = parseInt(digits, 10);
+    if (!isNaN(n) && n >= 1) setTestTpSize(n);
+  };
 
   // Live pricing from Cloudflare Worker
   const [livePricing, setLivePricing] = React.useState<Record<string, number>>({});
@@ -650,24 +687,27 @@ export default function QuickEstimate() {
       fields: [
         {
           label: 'Input sequence length (ISL)',
-          value: testISL,
+          value: islInput,
           term: 'isl',
           type: 'number' as const,
-          onChange: (val: string) => setTestISL(Math.max(1, parseInt(val) || 1))
+          invalid: invalidISL,
+          onChange: (val: string) => handleIslChange(val)
         },
         {
           label: 'Output sequence length (OSL)',
-          value: testOSL,
+          value: oslInput,
           term: 'osl',
           type: 'number' as const,
-          onChange: (val: string) => setTestOSL(Math.max(1, parseInt(val) || 1))
+          invalid: invalidOSL,
+          onChange: (val: string) => handleOslChange(val)
         },
         {
           label: 'Concurrent users',
-          value: testConcurrentUsers,
+          value: concurrentUsersInput,
           term: 'concurrent',
           type: 'number' as const,
-          onChange: (val: string) => setTestConcurrentUsers(Math.max(1, parseInt(val) || 1))
+          invalid: invalidUsers,
+          onChange: (val: string) => handleConcurrentUsersChange(val)
         },
       ],
     },
@@ -739,15 +779,16 @@ export default function QuickEstimate() {
       fields: [
         {
           label: 'Tensor parallel size',
-          value: `${testTpSize}`,
+          value: tpSizeInput,
           term: 'tensorParallel',
           readonly: false,
           type: 'number' as const,
-          onChange: (val: string) => setTestTpSize(parseInt(val) || 1),
+          invalid: invalidTpSize,
+          onChange: (val: string) => handleTpSizeChange(val),
         },
         {
           label: 'Total GPUs',
-          value: testResult ? `${testResult.memory_analysis.tp_size * testResult.memory_analysis.replicas}` : `${testTpSize}`,
+          value: testResult ? `${testResult.memory_analysis.tp_size * testResult.memory_analysis.replicas}` : `${tpSizeInput}`,
           readonly: true,
         },
       ],
@@ -890,13 +931,13 @@ export default function QuickEstimate() {
           <GpuSystemInput id="qe-gpu" value={gpu} onChange={setGpu} gpuOptions={aicGpus} />
 
         </div>
-
+        
         <div style={{ display: 'flex', justifyContent: 'flex-end', marginTop: 16 }}>
           <Button
             variant="primary"
             size="lg"
             onClick={() => { setTestResult(null); setCalcTrigger(t => t + 1); }}
-            isDisabled={isCalculating || !gpu || !model || catalogLoading}
+            isDisabled={isCalculating || !gpu || !model || catalogLoading || invalidISL || invalidOSL || invalidUsers || invalidTpSize}
           >
             {isCalculating ? 'Calculating...' : 'Calculate'}
           </Button>
@@ -1570,6 +1611,7 @@ export default function QuickEstimate() {
                             value={String(f.value)}
                             aria-label={f.label}
                             type="number"
+                            validated={f.invalid ? 'error' : 'default'}
                             onChange={(_, val) => f.onChange?.(val)}
                           />
                         ) : (

--- a/app/recommend/AdvancedEstimate.module.css
+++ b/app/recommend/AdvancedEstimate.module.css
@@ -128,6 +128,29 @@
   background: var(--bg);
   box-sizing: border-box;
 }
+.paramInputInvalid {
+  width: 100%;
+  height: 42px;
+  border: 1px solid var(--line2);
+  border-radius: 4px;
+  padding: 7px 11px;
+  font-size: 14px;
+  font-family: var(--sans);
+  background: var(--bg);
+  box-sizing: border-box;
+  border-color: #c9190b;
+  box-shadow: 0 0 0 1px #c9190b;
+}
+.paramInputInvalid:focus {
+  border-color: #c9190b;
+  box-shadow: 0 0 0 1px #c9190b;
+  outline: none;
+}
+.fieldError {
+  font-size: 12px;
+  color: #c9190b;
+  margin-top: 4px;
+}
 
 /* ---------- HF token ---------- */
 .hfSection {

--- a/app/recommend/AdvancedEstimate.tsx
+++ b/app/recommend/AdvancedEstimate.tsx
@@ -170,7 +170,7 @@ export default function AdvancedEstimate() {
 
   const invalidISL = islInput === '' || parseInt(islInput, 10) < 1;
   const invalidOSL = oslInput === '' || parseInt(oslInput, 10) < 1;
-  const invalidTTFT = ttftInput === '' || parseInt(ttftInput, 10) < 1;
+  const invalidTTFT = ttftInput === '' || !Number.isFinite(Number(ttftInput)) || Number(ttftInput) <= 0;
 
   const handleIslChange = (raw: string) => {
     const digits = raw.replace(/[^0-9]/g, '');
@@ -187,10 +187,10 @@ export default function AdvancedEstimate() {
   };
 
   const handleTtftChange = (raw: string) => {
-    const digits = raw.replace(/[^0-9]/g, '');
-    setTtftInput(digits);
-    const n = parseInt(digits, 10);
-    if (!isNaN(n) && n >= 1) setTtft(n);
+    const cleaned = raw.replace(/[^0-9.]/g, '');
+    setTtftInput(cleaned);
+    const n = Number(cleaned);
+    if (Number.isFinite(n) && n > 0) setTtft(n);
   };
 
 
@@ -313,7 +313,6 @@ export default function AdvancedEstimate() {
                   className={invalidISL ? styles.paramInputInvalid : styles.paramInput}
                   value={islInput}
                   onChange={e => handleIslChange(e.target.value)}
-                  // onChange={e => setIsl(Math.max(1, parseInt(e.target.value) || 1))}
                   min={1}
                 />
               </div>
@@ -324,7 +323,6 @@ export default function AdvancedEstimate() {
                   className={invalidOSL ? styles.paramInputInvalid : styles.paramInput}
                   value={oslInput}
                   onChange={e => handleOslChange(e.target.value)}
-                  // onChange={e => setOsl(Math.max(1, parseInt(e.target.value) || 1))}
                   min={1}
                 />
               </div>

--- a/app/recommend/AdvancedEstimate.tsx
+++ b/app/recommend/AdvancedEstimate.tsx
@@ -164,6 +164,35 @@ export default function AdvancedEstimate() {
   // Live pricing
   const [livePricing, setLivePricing] = React.useState<Record<string, number>>({});
 
+  const [islInput, setIslInput] = React.useState('2048');
+  const [oslInput, setOslInput] = React.useState('128');
+  const [ttftInput, setTtftInput] = React.useState('1000');
+
+  const invalidISL = islInput === '' || parseInt(islInput, 10) < 1;
+  const invalidOSL = oslInput === '' || parseInt(oslInput, 10) < 1;
+  const invalidTTFT = ttftInput === '' || parseInt(ttftInput, 10) < 1;
+
+  const handleIslChange = (raw: string) => {
+    const digits = raw.replace(/[^0-9]/g, '');
+    setIslInput(digits);
+    const n = parseInt(digits, 10);
+    if (!isNaN(n) && n >= 1) setIsl(n);
+  };
+
+  const handleOslChange = (raw: string) => {
+    const digits = raw.replace(/[^0-9]/g, '');
+    setOslInput(digits);
+    const n = parseInt(digits, 10);
+    if (!isNaN(n) && n >= 1) setOsl(n);
+  };
+
+  const handleTtftChange = (raw: string) => {
+    const digits = raw.replace(/[^0-9]/g, '');
+    setTtftInput(digits);
+    const n = parseInt(digits, 10);
+    if (!isNaN(n) && n >= 1) setTtft(n);
+  };
+
 
   // Model status check + fetch HF config
   React.useEffect(() => {
@@ -258,7 +287,7 @@ export default function AdvancedEstimate() {
           <button
             className={styles.calcBtn}
             onClick={handleCalculate}
-            disabled={isLoading || !model.includes('/')}
+            disabled={isLoading || !model.includes('/') || invalidISL || invalidOSL || invalidTTFT}
           >
             {isLoading ? 'Calculating...' : 'Calculate'}
           </button>
@@ -266,7 +295,7 @@ export default function AdvancedEstimate() {
       </div>
 
       <InfoStrip>
-        Based on your configuration — ISL {isl.toLocaleString()}, OSL {osl}, TTFT target {(ttft / 1000).toFixed(1)}s.
+        Based on your configuration — ISL {isl.toLocaleString()}, OSL {osl}, TTFT target {(ttft / 1000).toFixed(3)}s.
         {' '}<InfoStripAction onClick={() => setExpanded(expanded.includes('customize') ? expanded.filter(e => e !== 'customize') : [...expanded, 'customize'])}>
           Adjust? (edit fields below)
         </InfoStripAction>
@@ -281,9 +310,10 @@ export default function AdvancedEstimate() {
                 <label className={styles.fieldLabel}>Avg input tokens (ISL)</label>
                 <input
                   type="number"
-                  className={styles.paramInput}
-                  value={isl}
-                  onChange={e => setIsl(Math.max(1, parseInt(e.target.value) || 1))}
+                  className={invalidISL ? styles.paramInputInvalid : styles.paramInput}
+                  value={islInput}
+                  onChange={e => handleIslChange(e.target.value)}
+                  // onChange={e => setIsl(Math.max(1, parseInt(e.target.value) || 1))}
                   min={1}
                 />
               </div>
@@ -291,22 +321,20 @@ export default function AdvancedEstimate() {
                 <label className={styles.fieldLabel}>Avg output tokens (OSL)</label>
                 <input
                   type="number"
-                  className={styles.paramInput}
-                  value={osl}
-                  onChange={e => setOsl(Math.max(1, parseInt(e.target.value) || 1))}
+                  className={invalidOSL ? styles.paramInputInvalid : styles.paramInput}
+                  value={oslInput}
+                  onChange={e => handleOslChange(e.target.value)}
+                  // onChange={e => setOsl(Math.max(1, parseInt(e.target.value) || 1))}
                   min={1}
                 />
               </div>
               <div>
-                <label className={styles.fieldLabel}>Max TTFT (seconds)</label>
+                <label className={styles.fieldLabel}>Max TTFT (ms)</label>
                 <input
                   type="number"
-                  className={styles.paramInput}
-                  value={ttft / 1000}
-                  onChange={e => {
-                    const sec = parseFloat(e.target.value);
-                    if (!isNaN(sec) && sec > 0) setTtft(Math.round(sec * 1000));
-                  }}
+                  className={invalidTTFT ? styles.paramInputInvalid : styles.paramInput}
+                  value={ttftInput}
+                  onChange={e => handleTtftChange(e.target.value)}
                   min={0.1}
                   step={0.1}
                 />


### PR DESCRIPTION
Branch addresses this issue: https://github.com/redhat-performance/configiq/issues/6
If an invalid input is given, a red border is displayed and the calculate button is disabled
Also fixes the url links in the homepage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added validation for sizing, performance, and KV-cache calculator inputs.
  - Invalid or incomplete values now display clear error styling and prevent calculations until corrected.
  - Inputs preserve entered text while users edit values.
  - Advanced recommendations now accept TTFT targets in milliseconds and display results in seconds.
  - Updated homepage links for Recommend Sizing and Performance tools.
  - Non-numeric input characters are automatically filtered from numeric fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->