### PR TITLE
UI cleanup: hamburger position and Settings font consistency

### DIFF
--- a/app/settings/Settings.module.css
+++ b/app/settings/Settings.module.css
@@ -5,7 +5,7 @@
    ============================================================================ */
 
 .page {
-  font-family: var(--gc-font-sans);
+  font-family: var(--sans);
   color: var(--gc-text);
   font-size: 15px;
   line-height: 1.5;
@@ -18,7 +18,7 @@
 /* ── Page header ── */
 .header    { margin-bottom: 28px; }
 .pageTitle {
-  font-family: var(--gc-font-display);
+  font-family: var(--display);
   font-size: 30px;
   font-weight: 700;
   letter-spacing: -0.01em;
@@ -47,7 +47,7 @@
 }
 
 .sectionTitle {
-  font-family: var(--gc-font-sans);
+  font-family: var(--sans);
   font-size: 15px;
   font-weight: 600;
   color: var(--gc-text);
@@ -65,7 +65,7 @@
 .fieldWrap { display: flex; flex-direction: column; gap: 6px; }
 
 .fieldLabel {
-  font-family: var(--gc-font-mono);
+  font-family: var(--mono);
   font-size: 12px;
   font-weight: 600;
   letter-spacing: 0.06em;
@@ -86,7 +86,7 @@
   border-radius: 4px;
   padding: 7px 130px 7px 12px;
   font-size: 14px;
-  font-family: var(--gc-font-sans);
+  font-family: var(--sans);
   background: white;
   color: var(--gc-text);
   box-sizing: border-box;
@@ -116,7 +116,7 @@
   border-radius: 4px;
   padding: 7px 12px;
   font-size: 14px;
-  font-family: var(--gc-font-sans);
+  font-family: var(--sans);
   background: white;
   color: var(--gc-text);
   box-sizing: border-box;
@@ -161,7 +161,7 @@
   border-radius: 4px;
   padding: 7px 12px;
   font-size: 14px;
-  font-family: var(--gc-font-sans);
+  font-family: var(--sans);
   background: white;
   color: var(--gc-text);
   cursor: pointer;

--- a/components/layout/AppShell.tsx
+++ b/components/layout/AppShell.tsx
@@ -38,6 +38,11 @@ export function AppShell({ children }: { children: React.ReactNode }) {
 
   const masthead = (
     <Masthead style={{ backgroundColor: "#1a1a1a", borderBottom: "1px solid #2d2d2d" }}>
+      <MastheadToggle>
+        <PageToggleButton variant="plain" aria-label="Navigation" id="nav-toggle">
+          <BarsIcon color="white" />
+        </PageToggleButton>
+      </MastheadToggle>
       <MastheadMain>
         <MastheadBrand>
           <Link
@@ -78,11 +83,6 @@ export function AppShell({ children }: { children: React.ReactNode }) {
           <GithubIcon style={{ width: 21, height: 21 }} />
         </a>
       </MastheadContent>
-      <MastheadToggle>
-        <PageToggleButton variant="plain" aria-label="Navigation" id="nav-toggle">
-          <BarsIcon color="white" />
-        </PageToggleButton>
-      </MastheadToggle>
     </Masthead>
   );
 


### PR DESCRIPTION
- Move MastheadToggle before MastheadMain so the hamburger renders next to the logo, not below the header bar
- Replace --gc-font-sans/display/mono with --sans/display/mono on Settings page to match all other pages