### PR TITLE
fix: wire recommend constraints, add prefix length and workload presets

### DIFF
--- a/app/performance/PerformanceEstimate.tsx
+++ b/app/performance/PerformanceEstimate.tsx
@@ -208,7 +208,7 @@ export default function QuickEstimate() {
     setTestPrefix(isNaN(n) ? 0 : n);
   };
 
-  const applyPreset = (p: WorkloadPreset) => {
+  const applyPreset = (p: Pick<WorkloadPreset, 'isl' | 'osl' | 'concurrency' | 'prefix'>) => {
     setTestISL(p.isl); setIslInput(String(p.isl));
     setTestOSL(p.osl); setOslInput(String(p.osl));
     setTestConcurrentUsers(p.concurrency); setConcurrentUsersInput(String(p.concurrency));
@@ -943,16 +943,9 @@ export default function QuickEstimate() {
         <div style={{ display: 'flex', alignItems: 'center', gap: '8px', flexWrap: 'wrap', marginBottom: '12px' }}>
           <span style={{ fontSize: '12px', fontWeight: 600, fontFamily: 'var(--mono)', textTransform: 'uppercase', letterSpacing: '0.06em', color: '#3c3f42', whiteSpace: 'nowrap' }}>Workload:</span>
           {getAppConfig().workloadPresets.map(p => (
-            <button
-              key={p.key}
-              type="button"
-              onClick={() => applyPreset(p)}
-              style={{ fontSize: '12px', padding: '3px 10px', border: '1px solid #c6c7c8', borderRadius: '4px', background: '#fff', color: '#151515', cursor: 'pointer', fontFamily: 'var(--font-sans, sans-serif)', whiteSpace: 'nowrap' }}
-              onMouseEnter={e => (e.currentTarget.style.background = '#f0f0f0')}
-              onMouseLeave={e => (e.currentTarget.style.background = '#fff')}
-            >
+            <Button key={p.key} variant="tertiary" size="sm" onClick={() => applyPreset(p)}>
               {p.label}
-            </button>
+            </Button>
           ))}
         </div>
       )}

--- a/app/performance/PerformanceEstimate.tsx
+++ b/app/performance/PerformanceEstimate.tsx
@@ -34,6 +34,7 @@ import { useAicCatalog } from '@/lib/hooks/useAicCatalog';
 import { GpuChipLoader } from '@/components/GpuChipLoader/GpuChipLoader';
 import { useSettings } from '@/contexts/SettingsContext';
 import { getAppConfig } from '@/lib/app-config';
+import type { WorkloadPreset } from '@/lib/workload-presets';
 import type { InferenceConfigResult } from '@/lib/gpu-math/inference-config';
 import Link from 'next/link';
 
@@ -154,6 +155,7 @@ export default function QuickEstimate() {
   const [testConcurrentUsers, setTestConcurrentUsers] = React.useState(32);
   const [testISL, setTestISL] = React.useState(2048);
   const [testOSL, setTestOSL] = React.useState(128);
+  const [testPrefix, setTestPrefix] = React.useState(0);
   const [testTpSize, setTestTpSize] = React.useState(1);
   const [calcTrigger, setCalcTrigger] = React.useState(0);
   const [elapsed, setElapsed] = React.useState(0);
@@ -163,6 +165,7 @@ export default function QuickEstimate() {
   const [islInput, setIslInput] = React.useState('2048');
   const [oslInput, setOslInput] = React.useState('128');
   const [concurrentUsersInput, setConcurrentUsersInput] = React.useState('32');
+  const [prefixInput, setPrefixInput] = React.useState('0');
   const [tpSizeInput, setTpSizeInput] = React.useState('1');
 
   const invalidISL = islInput === '' || parseInt(islInput, 10) < 1;
@@ -196,6 +199,20 @@ export default function QuickEstimate() {
     setTpSizeInput(digits);
     const n = parseInt(digits, 10);
     if (!isNaN(n) && n >= 1) setTestTpSize(n);
+  };
+
+  const handlePrefixChange = (raw: string) => {
+    const digits = raw.replace(/[^0-9]/g, '');
+    setPrefixInput(digits);
+    const n = parseInt(digits, 10);
+    setTestPrefix(isNaN(n) ? 0 : n);
+  };
+
+  const applyPreset = (p: WorkloadPreset) => {
+    setTestISL(p.isl); setIslInput(String(p.isl));
+    setTestOSL(p.osl); setOslInput(String(p.osl));
+    setTestConcurrentUsers(p.concurrency); setConcurrentUsersInput(String(p.concurrency));
+    setTestPrefix(p.prefix); setPrefixInput(String(p.prefix));
   };
 
   // Live pricing from Cloudflare Worker
@@ -268,6 +285,7 @@ export default function QuickEstimate() {
           batch_size: testConcurrentUsers,
           tp_size: testTpSize,
           backend: inferenceBackend,
+          prefix: testPrefix > 0 ? testPrefix : undefined,
           vram_gb: currentAicGpu?.vramGb ?? null,
           gpu_memory_utilization: currentAicGpu?.gpuMemoryUtilization,
           backend_version: backendVersion || undefined,
@@ -683,6 +701,7 @@ export default function QuickEstimate() {
         { k: 'ISL', v: `${testISL}` },
         { k: 'OSL', v: `${testOSL}` },
         { k: 'users', v: `${testConcurrentUsers}` },
+        { k: 'prefix', v: `${testPrefix}` },
       ],
       fields: [
         {
@@ -708,6 +727,14 @@ export default function QuickEstimate() {
           type: 'number' as const,
           invalid: invalidUsers,
           onChange: (val: string) => handleConcurrentUsersChange(val)
+        },
+        {
+          label: 'Prefix length (tokens)',
+          value: prefixInput,
+          term: 'prefix',
+          type: 'number' as const,
+          invalid: false,
+          onChange: (val: string) => handlePrefixChange(val)
         },
       ],
     },
@@ -910,6 +937,25 @@ export default function QuickEstimate() {
         </div>
       </div>
 
+
+      {/* ---------- workload presets ---------- */}
+      {hydrated && getAppConfig().workloadPresets.length > 0 && (
+        <div style={{ display: 'flex', alignItems: 'center', gap: '8px', flexWrap: 'wrap', marginBottom: '12px' }}>
+          <span style={{ fontSize: '12px', fontWeight: 600, fontFamily: 'var(--mono)', textTransform: 'uppercase', letterSpacing: '0.06em', color: '#3c3f42', whiteSpace: 'nowrap' }}>Workload:</span>
+          {getAppConfig().workloadPresets.map(p => (
+            <button
+              key={p.key}
+              type="button"
+              onClick={() => applyPreset(p)}
+              style={{ fontSize: '12px', padding: '3px 10px', border: '1px solid #c6c7c8', borderRadius: '4px', background: '#fff', color: '#151515', cursor: 'pointer', fontFamily: 'var(--font-sans, sans-serif)', whiteSpace: 'nowrap' }}
+              onMouseEnter={e => (e.currentTarget.style.background = '#f0f0f0')}
+              onMouseLeave={e => (e.currentTarget.style.background = '#fff')}
+            >
+              {p.label}
+            </button>
+          ))}
+        </div>
+      )}
 
       {/* ---------- input row ---------- */}
       <div className={`${styles.card} ${styles.inputCard}`} data-tour="model">

--- a/app/recommend/AdvancedEstimate.tsx
+++ b/app/recommend/AdvancedEstimate.tsx
@@ -150,6 +150,10 @@ export default function AdvancedEstimate() {
   const [isl, setIsl] = React.useState(2048);
   const [osl, setOsl] = React.useState(128);
   const [ttft, setTtft] = React.useState(1000);
+  const [tpot, setTpot] = React.useState(30);
+  const [targetConcurrency, setTargetConcurrency] = React.useState(32);
+  const [requestLatency, setRequestLatency] = React.useState<number | null>(null);
+  const [prefix, setPrefix] = React.useState(0);
 
   // Model status + HF config
   const [modelStatus, setModelStatus] = React.useState<'idle' | 'supported' | 'catalog' | 'fetching' | 'fetched' | 'error'>('idle');
@@ -167,10 +171,16 @@ export default function AdvancedEstimate() {
   const [islInput, setIslInput] = React.useState('2048');
   const [oslInput, setOslInput] = React.useState('128');
   const [ttftInput, setTtftInput] = React.useState('1000');
+  const [tpotInput, setTpotInput] = React.useState('30');
+  const [concurrencyInput, setConcurrencyInput] = React.useState('32');
+  const [latencyInput, setLatencyInput] = React.useState('');
+  const [prefixInput, setPrefixInput] = React.useState('0');
 
   const invalidISL = islInput === '' || parseInt(islInput, 10) < 1;
   const invalidOSL = oslInput === '' || parseInt(oslInput, 10) < 1;
   const invalidTTFT = ttftInput === '' || !Number.isFinite(Number(ttftInput)) || Number(ttftInput) <= 0;
+  const invalidTpot = tpotInput === '' || !Number.isFinite(Number(tpotInput)) || Number(tpotInput) <= 0;
+  const invalidConcurrency = concurrencyInput === '' || parseInt(concurrencyInput, 10) < 1;
 
   const handleIslChange = (raw: string) => {
     const digits = raw.replace(/[^0-9]/g, '');
@@ -193,6 +203,33 @@ export default function AdvancedEstimate() {
     if (Number.isFinite(n) && n > 0) setTtft(n);
   };
 
+  const handleTpotChange = (raw: string) => {
+    const cleaned = raw.replace(/[^0-9.]/g, '');
+    setTpotInput(cleaned);
+    const n = Number(cleaned);
+    if (Number.isFinite(n) && n > 0) setTpot(n);
+  };
+
+  const handleConcurrencyChange = (raw: string) => {
+    const digits = raw.replace(/[^0-9]/g, '');
+    setConcurrencyInput(digits);
+    const n = parseInt(digits, 10);
+    if (!isNaN(n) && n >= 1) setTargetConcurrency(n);
+  };
+
+  const handleLatencyChange = (raw: string) => {
+    const cleaned = raw.replace(/[^0-9.]/g, '');
+    setLatencyInput(cleaned);
+    const n = Number(cleaned);
+    setRequestLatency(cleaned === '' ? null : (Number.isFinite(n) && n > 0 ? n : null));
+  };
+
+  const handlePrefixChange = (raw: string) => {
+    const digits = raw.replace(/[^0-9]/g, '');
+    setPrefixInput(digits);
+    const n = parseInt(digits, 10);
+    setPrefix(isNaN(n) ? 0 : n);
+  };
 
   // Model status check + fetch HF config
   React.useEffect(() => {
@@ -234,7 +271,12 @@ export default function AdvancedEstimate() {
   const currentGpuOption = aicGpus.find(g => g.systemId === gpuSystem) ?? aicGpus[0] ?? null;
 
   const handleCalculate = () => {
-    startSizing({ model_path: model, system: gpuSystem, isl, osl, ttft, tpot: 30, target_concurrency: 32, backend: inferenceBackend });
+    startSizing({
+      model_path: model, system: gpuSystem, isl, osl, ttft,
+      tpot, target_concurrency: targetConcurrency, prefix,
+      ...(requestLatency != null ? { request_latency: requestLatency } : {}),
+      backend: inferenceBackend,
+    });
   };
 
   // Local memory analysis using the same engine as Quick Estimate
@@ -287,7 +329,7 @@ export default function AdvancedEstimate() {
           <button
             className={styles.calcBtn}
             onClick={handleCalculate}
-            disabled={isLoading || !model.includes('/') || invalidISL || invalidOSL || invalidTTFT}
+            disabled={isLoading || !model.includes('/') || invalidISL || invalidOSL || invalidTTFT || invalidTpot || invalidConcurrency}
           >
             {isLoading ? 'Calculating...' : 'Calculate'}
           </button>
@@ -295,7 +337,7 @@ export default function AdvancedEstimate() {
       </div>
 
       <InfoStrip>
-        Based on your configuration — ISL {isl.toLocaleString()}, OSL {osl}, TTFT target {(ttft / 1000).toFixed(3)}s.
+        Based on your configuration — ISL {isl.toLocaleString()}, OSL {osl}, TTFT target {(ttft / 1000).toFixed(3)}s{prefix > 0 ? `, prefix ${prefix.toLocaleString()} tokens` : ''}, concurrency {targetConcurrency}, TPOT {tpot} ms.
         {' '}<InfoStripAction onClick={() => setExpanded(expanded.includes('customize') ? expanded.filter(e => e !== 'customize') : [...expanded, 'customize'])}>
           Adjust? (edit fields below)
         </InfoStripAction>
@@ -337,8 +379,17 @@ export default function AdvancedEstimate() {
                   step={0.1}
                 />
               </div>
+              <div>
+                <label className={styles.fieldLabel}>Prefix length (tokens)</label>
+                <input
+                  type="number"
+                  className={styles.paramInput}
+                  value={prefixInput}
+                  onChange={e => handlePrefixChange(e.target.value)}
+                  min={0}
+                />
+              </div>
             </div>
-
 
             {/* Additional constraints */}
             <Accordion style={{ marginTop: 12 }}>
@@ -355,16 +406,36 @@ export default function AdvancedEstimate() {
                 <AccordionContent isHidden={!expanded.includes('constraints')}>
                   <div className={styles.paramGrid} style={{ marginTop: 8 }}>
                     <div>
-                      <label className={styles.fieldLabel}>Batch size (optional)</label>
-                      <input type="number" className={styles.paramInput} placeholder="Auto" min={1} />
+                      <label className={styles.fieldLabel}>Target concurrency</label>
+                      <input
+                        type="number"
+                        className={invalidConcurrency ? styles.paramInputInvalid : styles.paramInput}
+                        value={concurrencyInput}
+                        onChange={e => handleConcurrencyChange(e.target.value)}
+                        min={1}
+                      />
                     </div>
                     <div>
-                      <label className={styles.fieldLabel}>Tokens/sec per user (optional)</label>
-                      <input type="number" className={styles.paramInput} placeholder="Auto" min={1} step={0.1} />
+                      <label className={styles.fieldLabel}>Max TPOT (ms)</label>
+                      <input
+                        type="number"
+                        className={invalidTpot ? styles.paramInputInvalid : styles.paramInput}
+                        value={tpotInput}
+                        onChange={e => handleTpotChange(e.target.value)}
+                        min={0.1}
+                        step={0.1}
+                      />
                     </div>
                     <div>
-                      <label className={styles.fieldLabel}>E2E latency ms (optional)</label>
-                      <input type="number" className={styles.paramInput} placeholder="Auto" min={1} />
+                      <label className={styles.fieldLabel}>Max E2E latency (ms, optional)</label>
+                      <input
+                        type="number"
+                        className={styles.paramInput}
+                        value={latencyInput}
+                        onChange={e => handleLatencyChange(e.target.value)}
+                        placeholder="Auto"
+                        min={1}
+                      />
                     </div>
                   </div>
                 </AccordionContent>

--- a/app/recommend/AdvancedEstimate.tsx
+++ b/app/recommend/AdvancedEstimate.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import * as React from 'react';
-import { Label, Accordion, AccordionItem, AccordionToggle, AccordionContent } from '@patternfly/react-core';
+import { Label, Button, Accordion, AccordionItem, AccordionToggle, AccordionContent } from '@patternfly/react-core';
 import MicrochipIcon from '@patternfly/react-icons/dist/esm/icons/microchip-icon';
 import MemoryIcon from '@patternfly/react-icons/dist/esm/icons/memory-icon';
 import ClockIcon from '@patternfly/react-icons/dist/esm/icons/clock-icon';
@@ -182,6 +182,7 @@ export default function AdvancedEstimate() {
   const invalidTTFT = ttftInput === '' || !Number.isFinite(Number(ttftInput)) || Number(ttftInput) <= 0;
   const invalidTpot = tpotInput === '' || !Number.isFinite(Number(tpotInput)) || Number(tpotInput) <= 0;
   const invalidConcurrency = concurrencyInput === '' || parseInt(concurrencyInput, 10) < 1;
+  const invalidLatency = latencyInput !== '' && (!Number.isFinite(Number(latencyInput)) || Number(latencyInput) <= 0);
 
   const handleIslChange = (raw: string) => {
     const digits = raw.replace(/[^0-9]/g, '');
@@ -340,7 +341,7 @@ export default function AdvancedEstimate() {
           <button
             className={styles.calcBtn}
             onClick={handleCalculate}
-            disabled={isLoading || !model.includes('/') || invalidISL || invalidOSL || invalidTTFT || invalidTpot || invalidConcurrency}
+            disabled={isLoading || !model.includes('/') || invalidISL || invalidOSL || invalidTTFT || invalidTpot || invalidConcurrency || invalidLatency}
           >
             {isLoading ? 'Calculating...' : 'Calculate'}
           </button>
@@ -351,16 +352,9 @@ export default function AdvancedEstimate() {
         <div style={{ display: 'flex', alignItems: 'center', gap: '8px', flexWrap: 'wrap', marginBottom: '12px' }}>
           <span style={{ fontSize: '12px', fontWeight: 600, fontFamily: 'var(--mono)', textTransform: 'uppercase', letterSpacing: '0.06em', color: '#3c3f42', whiteSpace: 'nowrap' }}>Workload:</span>
           {getAppConfig().workloadPresets.map(p => (
-            <button
-              key={p.key}
-              type="button"
-              onClick={() => applyPreset(p)}
-              style={{ fontSize: '12px', padding: '3px 10px', border: '1px solid #c6c7c8', borderRadius: '4px', background: '#fff', color: '#151515', cursor: 'pointer', fontFamily: 'var(--font-sans, sans-serif)', whiteSpace: 'nowrap' }}
-              onMouseEnter={e => (e.currentTarget.style.background = '#f0f0f0')}
-              onMouseLeave={e => (e.currentTarget.style.background = '#fff')}
-            >
+            <Button key={p.key} variant="tertiary" size="sm" onClick={() => applyPreset(p)}>
               {p.label}
-            </button>
+            </Button>
           ))}
         </div>
       )}
@@ -459,7 +453,7 @@ export default function AdvancedEstimate() {
                       <label className={styles.fieldLabel}>Max E2E latency (ms, optional)</label>
                       <input
                         type="number"
-                        className={styles.paramInput}
+                        className={invalidLatency ? styles.paramInputInvalid : styles.paramInput}
                         value={latencyInput}
                         onChange={e => handleLatencyChange(e.target.value)}
                         placeholder="Auto"

--- a/app/recommend/AdvancedEstimate.tsx
+++ b/app/recommend/AdvancedEstimate.tsx
@@ -18,6 +18,7 @@ import { useGpuSizer } from '@/contexts/GpuSizerContext';
 import { useAicCatalog } from '@/lib/hooks/useAicCatalog';
 import { useSettings } from '@/contexts/SettingsContext';
 import { getAppConfig } from '@/lib/app-config';
+import type { WorkloadPreset } from '@/lib/workload-presets';
 import { ModelInput } from '@/components/ui/ModelInput';
 import { GpuSystemInput } from '@/components/ui/GpuSystemInput';
 
@@ -270,6 +271,16 @@ export default function AdvancedEstimate() {
 
   const currentGpuOption = aicGpus.find(g => g.systemId === gpuSystem) ?? aicGpus[0] ?? null;
 
+  const applyPreset = (p: WorkloadPreset) => {
+    setIsl(p.isl); setIslInput(String(p.isl));
+    setOsl(p.osl); setOslInput(String(p.osl));
+    setTtft(p.ttft); setTtftInput(String(p.ttft));
+    setTpot(p.tpot); setTpotInput(String(p.tpot));
+    setTargetConcurrency(p.concurrency); setConcurrencyInput(String(p.concurrency));
+    setPrefix(p.prefix); setPrefixInput(String(p.prefix));
+    setExpanded(prev => prev.includes('customize') ? prev : [...prev, 'customize']);
+  };
+
   const handleCalculate = () => {
     startSizing({
       model_path: model, system: gpuSystem, isl, osl, ttft,
@@ -335,6 +346,24 @@ export default function AdvancedEstimate() {
           </button>
         </div>
       </div>
+
+      {hydrated && getAppConfig().workloadPresets.length > 0 && (
+        <div style={{ display: 'flex', alignItems: 'center', gap: '8px', flexWrap: 'wrap', marginBottom: '12px' }}>
+          <span style={{ fontSize: '12px', fontWeight: 600, fontFamily: 'var(--mono)', textTransform: 'uppercase', letterSpacing: '0.06em', color: '#3c3f42', whiteSpace: 'nowrap' }}>Workload:</span>
+          {getAppConfig().workloadPresets.map(p => (
+            <button
+              key={p.key}
+              type="button"
+              onClick={() => applyPreset(p)}
+              style={{ fontSize: '12px', padding: '3px 10px', border: '1px solid #c6c7c8', borderRadius: '4px', background: '#fff', color: '#151515', cursor: 'pointer', fontFamily: 'var(--font-sans, sans-serif)', whiteSpace: 'nowrap' }}
+              onMouseEnter={e => (e.currentTarget.style.background = '#f0f0f0')}
+              onMouseLeave={e => (e.currentTarget.style.background = '#fff')}
+            >
+              {p.label}
+            </button>
+          ))}
+        </div>
+      )}
 
       <InfoStrip>
         Based on your configuration — ISL {isl.toLocaleString()}, OSL {osl}, TTFT target {(ttft / 1000).toFixed(3)}s{prefix > 0 ? `, prefix ${prefix.toLocaleString()} tokens` : ''}, concurrency {targetConcurrency}, TPOT {tpot} ms.

--- a/contexts/GpuSizerContext.tsx
+++ b/contexts/GpuSizerContext.tsx
@@ -13,6 +13,8 @@ interface GpuSizerParams {
   backend?: string;
   target_concurrency?: number;
   target_request_rate?: number;
+  request_latency?: number;
+  prefix?: number;
 }
 
 interface GpuSizerState {
@@ -93,6 +95,8 @@ export function GpuSizerProvider({ children }: { children: React.ReactNode }) {
       delete requestBody.target_concurrency;
       requestBody.target_request_rate = p.target_request_rate;
     }
+    if (p.request_latency != null) requestBody.request_latency = p.request_latency;
+    if (p.prefix != null && p.prefix > 0) requestBody.prefix = p.prefix;
 
     setParams(p);
     setIsLoading(true);

--- a/lib/api/estimate-adapter.ts
+++ b/lib/api/estimate-adapter.ts
@@ -33,6 +33,7 @@ export interface EstimateAdapterInput {
   hf_model_config?: Record<string, unknown> | null
   moe_ep_size?: number
   moe_tp_size?: number
+  prefix?: number
 }
 
 function isMoeConfig(config: Record<string, unknown> | null | undefined): boolean {
@@ -78,6 +79,7 @@ export async function fetchEstimateAsInferenceResult(
   }
 
   if (input.backend_version) body.backend_version = input.backend_version
+  if (input.prefix != null && input.prefix > 0) body.prefix = input.prefix
 
   if (input.hf_model_config) {
     body.model_config = input.hf_model_config

--- a/lib/app-config.ts
+++ b/lib/app-config.ts
@@ -1,3 +1,5 @@
+import type { WorkloadPreset } from './workload-presets';
+
 export interface AppConfig {
   defaultModel: string;
   defaultSystem: string;
@@ -8,6 +10,7 @@ export interface AppConfig {
   supportedModels: string[];
   suggestedModelNames: string[];
   modelRequestUrl: string;
+  workloadPresets: WorkloadPreset[];
 }
 
 // Hardcoded fallback — used if /config.json fails to load
@@ -25,6 +28,7 @@ const FALLBACK: AppConfig = {
   supportedModels: [],
   suggestedModelNames: [],
   modelRequestUrl: '',
+  workloadPresets: [],
 };
 
 let cached: AppConfig | null = null;
@@ -45,6 +49,7 @@ export async function loadAppConfig(): Promise<AppConfig> {
       supportedModels: data.supportedModels ?? FALLBACK.supportedModels,
       suggestedModelNames: data.suggestedModelNames ?? FALLBACK.suggestedModelNames,
       modelRequestUrl: data.modelRequestUrl ?? FALLBACK.modelRequestUrl,
+      workloadPresets: data.workloadPresets ?? FALLBACK.workloadPresets,
     };
   } catch {
     cached = FALLBACK;

--- a/lib/workload-presets.ts
+++ b/lib/workload-presets.ts
@@ -1,0 +1,10 @@
+export interface WorkloadPreset {
+  key: string
+  label: string
+  isl: number
+  osl: number
+  ttft: number
+  tpot: number
+  concurrency: number
+  prefix: number
+}

--- a/public/config.json
+++ b/public/config.json
@@ -30,5 +30,13 @@
     "nvidia/Kimi-K2.5-NVFP4",
     "moonshotai/Kimi-K3"
   ],
-  "modelRequestUrl": "https://github.com/redhat-performance/configiq/issues/new?labels=model-request&title=[Model+Request]+"
+  "modelRequestUrl": "https://github.com/redhat-performance/configiq/issues/new?labels=model-request&title=[Model+Request]+",
+  "workloadPresets": [
+    { "key": "chat",    "label": "Interactive chat",  "isl":  512, "osl":  256, "ttft":   500, "tpot":  30, "concurrency":  32, "prefix":    0 },
+    { "key": "rag",     "label": "RAG",               "isl": 2048, "osl":  256, "ttft":  1000, "tpot":  50, "concurrency":  32, "prefix":  512 },
+    { "key": "agentic", "label": "Agentic",           "isl": 4096, "osl":  512, "ttft":  2000, "tpot":  50, "concurrency":  16, "prefix": 1024 },
+    { "key": "coding",  "label": "Coding",            "isl": 2048, "osl": 1024, "ttft":  2000, "tpot":  30, "concurrency":  16, "prefix":  512 },
+    { "key": "batch",   "label": "Batch / offline",   "isl": 4096, "osl": 1024, "ttft": 10000, "tpot": 100, "concurrency": 128, "prefix":    0 },
+    { "key": "voice",   "label": "Voice / real-time", "isl":  256, "osl":  128, "ttft":   300, "tpot":  15, "concurrency":  64, "prefix":    0 }
+  ]
 }


### PR DESCRIPTION
## Summary

- **Fixes #45** — Additional constraints in the Recommend page (target concurrency, max TPOT, max E2E latency) had no state, no `onChange` handlers, and were not passed to the API. `tpot` and `target_concurrency` were hardcoded at 30ms and 32 respectively. All three fields are now wired through to `startSizing`. Field labels corrected: "Batch size" → "Target concurrency", "Tokens/sec per user" → "Max TPOT (ms)".
- **Fixes #41** — Adds prefix length input (tokens) to both Recommend and Performance Estimate pages, passed through to the AIC API. Adds six config-driven workload presets (interactive chat, RAG, agentic, coding, batch/offline, voice/real-time) that pre-fill ISL, OSL, TTFT, TPOT, concurrency, and prefix in one click. Presets live in `public/config.json` so operators can tune values without a code change.

## Commits

1. `fix: wire additional constraints to recommend API, add prefix length` — #45 + partial #41
2. `feat: workload presets and prefix length for Recommend and Performance pages` — completes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added workload presets for common scenarios, including chat, RAG, agentic, coding, batch, and voice workloads.
  * Added prefix-cache configuration to performance and recommendation estimates.
  * Added advanced controls for TPOT, concurrency, request latency, and prefix length.
  * Presets now populate supported workload settings and appear in configuration summaries.
* **Bug Fixes**
  * Disabled calculations when TPOT or concurrency values are invalid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->