### PR TITLE
fix: workload UX improvements on Recommend and Performance pages

### DIFF
--- a/app/performance/PerformanceEstimate.tsx
+++ b/app/performance/PerformanceEstimate.tsx
@@ -34,7 +34,7 @@ import { useAicCatalog } from '@/lib/hooks/useAicCatalog';
 import { GpuChipLoader } from '@/components/GpuChipLoader/GpuChipLoader';
 import { useSettings } from '@/contexts/SettingsContext';
 import { getAppConfig } from '@/lib/app-config';
-import type { WorkloadPreset } from '@/lib/workload-presets';
+import { DEFAULT_WORKLOAD, type WorkloadPreset } from '@/lib/workload-presets';
 import type { InferenceConfigResult } from '@/lib/gpu-math/inference-config';
 import Link from 'next/link';
 
@@ -214,6 +214,8 @@ export default function QuickEstimate() {
     setTestConcurrentUsers(p.concurrency); setConcurrentUsersInput(String(p.concurrency));
     setTestPrefix(p.prefix); setPrefixInput(String(p.prefix));
   };
+
+  const resetToDefaults = () => applyPreset(DEFAULT_WORKLOAD);
 
   // Live pricing from Cloudflare Worker
   const [livePricing, setLivePricing] = React.useState<Record<string, number>>({});
@@ -938,18 +940,6 @@ export default function QuickEstimate() {
       </div>
 
 
-      {/* ---------- workload presets ---------- */}
-      {hydrated && getAppConfig().workloadPresets.length > 0 && (
-        <div style={{ display: 'flex', alignItems: 'center', gap: '8px', flexWrap: 'wrap', marginBottom: '12px' }}>
-          <span style={{ fontSize: '12px', fontWeight: 600, fontFamily: 'var(--mono)', textTransform: 'uppercase', letterSpacing: '0.06em', color: '#3c3f42', whiteSpace: 'nowrap' }}>Workload:</span>
-          {getAppConfig().workloadPresets.map(p => (
-            <Button key={p.key} variant="tertiary" size="sm" onClick={() => applyPreset(p)}>
-              {p.label}
-            </Button>
-          ))}
-        </div>
-      )}
-
       {/* ---------- input row ---------- */}
       <div className={`${styles.card} ${styles.inputCard}`} data-tour="model">
         <div className={styles.inputRow}>
@@ -983,6 +973,19 @@ export default function QuickEstimate() {
         </div>
 
       </div>
+
+      {/* ---------- workload presets ---------- */}
+      {hydrated && (
+        <div style={{ display: 'flex', alignItems: 'center', gap: '8px', flexWrap: 'wrap', marginBottom: '12px' }}>
+          <span style={{ fontSize: '12px', fontWeight: 600, fontFamily: 'var(--mono)', textTransform: 'uppercase', letterSpacing: '0.06em', color: '#3c3f42', whiteSpace: 'nowrap' }}>Workload:</span>
+          <Button variant="tertiary" size="sm" onClick={resetToDefaults}>Default</Button>
+          {getAppConfig().workloadPresets.map(p => (
+            <Button key={p.key} variant="tertiary" size="sm" onClick={() => applyPreset(p)}>
+              {p.label}
+            </Button>
+          ))}
+        </div>
+      )}
 
       <InfoStrip data-tour="warning">
         Based on your configuration — ISL {testISL}, OSL {testOSL}, {testKVCachePrecision} KV cache,

--- a/app/performance/PerformanceEstimate.tsx
+++ b/app/performance/PerformanceEstimate.tsx
@@ -208,11 +208,14 @@ export default function QuickEstimate() {
     setTestPrefix(isNaN(n) ? 0 : n);
   };
 
-  const applyPreset = (p: Pick<WorkloadPreset, 'isl' | 'osl' | 'concurrency' | 'prefix'>) => {
+  const [activePreset, setActivePreset] = React.useState<string>('default');
+
+  const applyPreset = (p: Pick<WorkloadPreset, 'key' | 'isl' | 'osl' | 'concurrency' | 'prefix'>) => {
     setTestISL(p.isl); setIslInput(String(p.isl));
     setTestOSL(p.osl); setOslInput(String(p.osl));
     setTestConcurrentUsers(p.concurrency); setConcurrentUsersInput(String(p.concurrency));
     setTestPrefix(p.prefix); setPrefixInput(String(p.prefix));
+    setActivePreset(p.key);
   };
 
   const resetToDefaults = () => applyPreset(DEFAULT_WORKLOAD);
@@ -978,9 +981,9 @@ export default function QuickEstimate() {
       {hydrated && (
         <div style={{ display: 'flex', alignItems: 'center', gap: '8px', flexWrap: 'wrap', marginBottom: '12px' }}>
           <span style={{ fontSize: '12px', fontWeight: 600, fontFamily: 'var(--mono)', textTransform: 'uppercase', letterSpacing: '0.06em', color: '#3c3f42', whiteSpace: 'nowrap' }}>Workload:</span>
-          <Button variant="tertiary" size="sm" onClick={resetToDefaults}>Default</Button>
+          <Button variant={activePreset === 'default' ? 'secondary' : 'tertiary'} size="sm" onClick={resetToDefaults}>Default</Button>
           {getAppConfig().workloadPresets.map(p => (
-            <Button key={p.key} variant="tertiary" size="sm" onClick={() => applyPreset(p)}>
+            <Button key={p.key} variant={activePreset === p.key ? 'secondary' : 'tertiary'} size="sm" onClick={() => applyPreset(p)}>
               {p.label}
             </Button>
           ))}

--- a/app/recommend/AdvancedEstimate.tsx
+++ b/app/recommend/AdvancedEstimate.tsx
@@ -18,7 +18,7 @@ import { useGpuSizer } from '@/contexts/GpuSizerContext';
 import { useAicCatalog } from '@/lib/hooks/useAicCatalog';
 import { useSettings } from '@/contexts/SettingsContext';
 import { getAppConfig } from '@/lib/app-config';
-import type { WorkloadPreset } from '@/lib/workload-presets';
+import { DEFAULT_WORKLOAD, type WorkloadPreset } from '@/lib/workload-presets';
 import { ModelInput } from '@/components/ui/ModelInput';
 import { GpuSystemInput } from '@/components/ui/GpuSystemInput';
 
@@ -282,6 +282,11 @@ export default function AdvancedEstimate() {
     setExpanded(prev => prev.includes('customize') ? prev : [...prev, 'customize']);
   };
 
+  const resetToDefaults = () => {
+    applyPreset(DEFAULT_WORKLOAD);
+    setRequestLatency(null); setLatencyInput('');
+  };
+
   const handleCalculate = () => {
     startSizing({
       model_path: model, system: gpuSystem, isl, osl, ttft,
@@ -348,9 +353,10 @@ export default function AdvancedEstimate() {
         </div>
       </div>
 
-      {hydrated && getAppConfig().workloadPresets.length > 0 && (
+      {hydrated && (
         <div style={{ display: 'flex', alignItems: 'center', gap: '8px', flexWrap: 'wrap', marginBottom: '12px' }}>
           <span style={{ fontSize: '12px', fontWeight: 600, fontFamily: 'var(--mono)', textTransform: 'uppercase', letterSpacing: '0.06em', color: '#3c3f42', whiteSpace: 'nowrap' }}>Workload:</span>
+          <Button variant="tertiary" size="sm" onClick={resetToDefaults}>Default</Button>
           {getAppConfig().workloadPresets.map(p => (
             <Button key={p.key} variant="tertiary" size="sm" onClick={() => applyPreset(p)}>
               {p.label}

--- a/app/recommend/AdvancedEstimate.tsx
+++ b/app/recommend/AdvancedEstimate.tsx
@@ -272,6 +272,8 @@ export default function AdvancedEstimate() {
 
   const currentGpuOption = aicGpus.find(g => g.systemId === gpuSystem) ?? aicGpus[0] ?? null;
 
+  const [activePreset, setActivePreset] = React.useState<string>('default');
+
   const applyPreset = (p: WorkloadPreset) => {
     setIsl(p.isl); setIslInput(String(p.isl));
     setOsl(p.osl); setOslInput(String(p.osl));
@@ -279,6 +281,7 @@ export default function AdvancedEstimate() {
     setTpot(p.tpot); setTpotInput(String(p.tpot));
     setTargetConcurrency(p.concurrency); setConcurrencyInput(String(p.concurrency));
     setPrefix(p.prefix); setPrefixInput(String(p.prefix));
+    setActivePreset(p.key);
     setExpanded(prev => prev.includes('customize') ? prev : [...prev, 'customize']);
   };
 
@@ -356,9 +359,9 @@ export default function AdvancedEstimate() {
       {hydrated && (
         <div style={{ display: 'flex', alignItems: 'center', gap: '8px', flexWrap: 'wrap', marginBottom: '12px' }}>
           <span style={{ fontSize: '12px', fontWeight: 600, fontFamily: 'var(--mono)', textTransform: 'uppercase', letterSpacing: '0.06em', color: '#3c3f42', whiteSpace: 'nowrap' }}>Workload:</span>
-          <Button variant="tertiary" size="sm" onClick={resetToDefaults}>Default</Button>
+          <Button variant={activePreset === 'default' ? 'secondary' : 'tertiary'} size="sm" onClick={resetToDefaults}>Default</Button>
           {getAppConfig().workloadPresets.map(p => (
-            <Button key={p.key} variant="tertiary" size="sm" onClick={() => applyPreset(p)}>
+            <Button key={p.key} variant={activePreset === p.key ? 'secondary' : 'tertiary'} size="sm" onClick={() => applyPreset(p)}>
               {p.label}
             </Button>
           ))}
@@ -420,7 +423,7 @@ export default function AdvancedEstimate() {
                   )}
                   isExpanded={expanded.includes('constraints')}
                 >
-                  Additional constraints
+                  Additional constraints (optional)
                 </AccordionToggle>
                 <AccordionContent isHidden={!expanded.includes('constraints')}>
                   <div className={styles.paramGrid} style={{ marginTop: 8, gridTemplateColumns: 'repeat(4, 1fr)' }}>

--- a/app/recommend/AdvancedEstimate.tsx
+++ b/app/recommend/AdvancedEstimate.tsx
@@ -450,7 +450,7 @@ export default function AdvancedEstimate() {
                       />
                     </div>
                     <div>
-                      <label className={styles.fieldLabel}>Max E2E latency (ms, optional)</label>
+                      <label className={styles.fieldLabel}>Max E2E latency (ms)</label>
                       <input
                         type="number"
                         className={invalidLatency ? styles.paramInputInvalid : styles.paramInput}

--- a/app/recommend/AdvancedEstimate.tsx
+++ b/app/recommend/AdvancedEstimate.tsx
@@ -402,16 +402,6 @@ export default function AdvancedEstimate() {
                   step={0.1}
                 />
               </div>
-              <div>
-                <label className={styles.fieldLabel}>Prefix length (tokens)</label>
-                <input
-                  type="number"
-                  className={styles.paramInput}
-                  value={prefixInput}
-                  onChange={e => handlePrefixChange(e.target.value)}
-                  min={0}
-                />
-              </div>
             </div>
 
             {/* Additional constraints */}
@@ -427,7 +417,7 @@ export default function AdvancedEstimate() {
                   Additional constraints
                 </AccordionToggle>
                 <AccordionContent isHidden={!expanded.includes('constraints')}>
-                  <div className={styles.paramGrid} style={{ marginTop: 8 }}>
+                  <div className={styles.paramGrid} style={{ marginTop: 8, gridTemplateColumns: 'repeat(4, 1fr)' }}>
                     <div>
                       <label className={styles.fieldLabel}>Target concurrency</label>
                       <input
@@ -447,6 +437,16 @@ export default function AdvancedEstimate() {
                         onChange={e => handleTpotChange(e.target.value)}
                         min={0.1}
                         step={0.1}
+                      />
+                    </div>
+                    <div>
+                      <label className={styles.fieldLabel}>Prefix length (tokens)</label>
+                      <input
+                        type="number"
+                        className={styles.paramInput}
+                        value={prefixInput}
+                        onChange={e => handlePrefixChange(e.target.value)}
+                        min={0}
                       />
                     </div>
                     <div>

--- a/lib/workload-presets.ts
+++ b/lib/workload-presets.ts
@@ -8,3 +8,14 @@ export interface WorkloadPreset {
   concurrency: number
   prefix: number
 }
+
+export const DEFAULT_WORKLOAD: WorkloadPreset = {
+  key: 'default',
+  label: 'Default',
+  isl: 2048,
+  osl: 128,
+  ttft: 1000,
+  tpot: 30,
+  concurrency: 32,
+  prefix: 0,
+}


### PR DESCRIPTION
## Summary

Follows up on #45 — the TPOT field existed but was buried in a collapsed accordion making it invisible. Also improves workload preset UX across both pages.

- **Recommend page**: Move Prefix length into Additional constraints accordion; accordion goes 4-column so all four fields (concurrency, TPOT, prefix, E2E latency) sit on one row. Main param grid is now a clean 3-field row (ISL, OSL, TTFT). Label accordion "(optional)".
- **Both pages**: Add a "Default" workload button that resets all fields to baseline values. Active preset is highlighted (blue-bordered) on page load and when clicked.
- **Performance page**: Move workload preset row from above the model/GPU card to below it, matching the Recommend page layout.
- **Shared**: Extract `DEFAULT_WORKLOAD` constant into `lib/workload-presets.ts` so both pages share the same baseline values.

## Test plan

- [ ] Recommend page: main grid shows ISL/OSL/TTFT only; Additional constraints accordion shows concurrency/TPOT/prefix/E2E on one row
- [ ] "Default" button is blue-bordered on page load; clicking a named preset highlights it instead
- [ ] Default button resets all fields to ISL 2048, OSL 128, TTFT 1000, TPOT 30, concurrency 32, prefix 0
- [ ] Performance page: workload preset row appears below model/GPU card, not above
- [ ] Performance page: Default button works and highlights correctly

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)