### PR TITLE
fix: remove duplicate Hardware accordion; wire precision to AIC API

### DIFF
--- a/app/performance/PerformanceEstimate.tsx
+++ b/app/performance/PerformanceEstimate.tsx
@@ -43,9 +43,6 @@ function modelSuggestions(): string {
   return names.length > 0 ? names.join(', ') : 'Nemotron, DeepSeek V4, Gemma 4, Kimi';
 }
 
-function gpuOptionLabel(label: string, vramGb: number | null): string {
-  return vramGb ? `${label} — ${vramGb} GB` : label;
-}
 
 const QUICK_ESTIMATE_TOUR: TourStep[] = [
   {
@@ -290,6 +287,8 @@ export default function QuickEstimate() {
           gpu_memory_utilization: currentAicGpu?.gpuMemoryUtilization,
           backend_version: backendVersion || undefined,
           hf_model_config: hfConfig as Record<string, unknown> | null,
+          kvcache_quant_mode: testKVCachePrecision === 'FP8' ? 'fp8' : null,
+          gemm_quant_mode: testWeightPrecision === 'FP8' ? 'fp8' : testWeightPrecision === 'INT8' ? 'int8' : testWeightPrecision === 'INT4' ? 'int4' : null,
           ...(isMoe && { moe_ep_size: testTpSize }),
         });
         if (!cancelled) {
@@ -759,22 +758,6 @@ export default function QuickEstimate() {
           type: 'select' as const,
           options: ['FP16', 'FP8'] as const,
           onChange: (val: string) => setTestKVCachePrecision(val as any)
-        },
-      ],
-    },
-    {
-      id: 'hardware', title: 'Hardware',
-      summary: [{ k: 'GPU', v: currentAicGpu ? gpuOptionLabel(currentAicGpu.label, currentAicGpu.vramGb) : gpu }],
-      fields: [
-        {
-          label: 'GPU type',
-          value: gpu,
-          type: 'select' as const,
-          options: aicGpus.map(g => gpuOptionLabel(g.label, g.vramGb)),
-          onChange: (val: string) => {
-            const match = aicGpus.find(g => gpuOptionLabel(g.label, g.vramGb) === val)
-            if (match) setGpu(match.systemId)
-          }
         },
       ],
     },

--- a/lib/api/estimate-adapter.ts
+++ b/lib/api/estimate-adapter.ts
@@ -34,6 +34,8 @@ export interface EstimateAdapterInput {
   moe_ep_size?: number
   moe_tp_size?: number
   prefix?: number
+  kvcache_quant_mode?: string | null
+  gemm_quant_mode?: string | null
 }
 
 function isMoeConfig(config: Record<string, unknown> | null | undefined): boolean {
@@ -80,6 +82,8 @@ export async function fetchEstimateAsInferenceResult(
 
   if (input.backend_version) body.backend_version = input.backend_version
   if (input.prefix != null && input.prefix > 0) body.prefix = input.prefix
+  if (input.kvcache_quant_mode) body.kvcache_quant_mode = input.kvcache_quant_mode
+  if (input.gemm_quant_mode) body.gemm_quant_mode = input.gemm_quant_mode
 
   if (input.hf_model_config) {
     body.model_config = input.hf_model_config


### PR DESCRIPTION
## Summary
- Remove duplicate Hardware accordion section from Performance page (was setting the same `gpu` state as the top-level GpuSystemInput)
- Wire KV cache precision and weight precision to AIC `/estimate` API via `kvcache_quant_mode` and `gemm_quant_mode` parameters

## Changes
- **app/performance/PerformanceEstimate.tsx**
  - Remove duplicate Hardware accordion (lines 765-780)
  - Wire precision parameters to API call:
    - `kvcache_quant_mode: testKVCachePrecision === 'FP8' ? 'fp8' : null`
    - `gemm_quant_mode` maps FP8/INT8/INT4 to lowercase strings, null otherwise
- **lib/api/estimate-adapter.ts**
  - Add `kvcache_quant_mode` and `gemm_quant_mode` to `EstimateAdapterInput` interface
  - Pass both params to AIC API request body when present

## Test plan
- [ ] Verify Hardware accordion no longer appears on Performance page
- [ ] Change KV cache precision to FP8, confirm API request includes `kvcache_quant_mode: "fp8"`
- [ ] Change weight precision to FP8/INT8/INT4, confirm API request includes correct `gemm_quant_mode`
- [ ] Confirm estimate results reflect precision choices

🤖 Generated with [Claude Code](https://claude.com/claude-code)