### PR TITLE
fix(build): install git in builder so navbar shows real version

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -3,6 +3,8 @@ ARG NEXT_PUBLIC_AICONFIGURATOR_API_URL=https://aiconfigurator.dev
 
 FROM node:20-alpine AS builder
 
+RUN apk add --no-cache git
+
 WORKDIR /app
 
 COPY package.json package-lock.json ./


### PR DESCRIPTION
## Summary

- `inject-build-metadata.js` runs `git rev-parse HEAD` and `git describe --tags` at build time to set `NEXT_PUBLIC_GIT_COMMIT` and `NEXT_PUBLIC_GIT_VERSION`
- `node:20-alpine` has no git binary — both calls failed silently, leaving the navbar showing `unknown` for commit and the hardcoded fallback (`0.2.0`) for version instead of the real git tag
- Fix: `apk add --no-cache git` in the builder stage only — no impact on the runtime image size

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application build environment to include Git, improving reliability during dependency installation and production builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->