### PR TITLE
feat(performance): add MXFP4 precision, Pipeline Parallel, and MoE quantization support

### DIFF
--- a/app/compare/page.tsx
+++ b/app/compare/page.tsx
@@ -193,6 +193,7 @@ export default function ComparePage() {
       ['', ...estimates.map(() => '')], // Separator
       ['GPUs needed', ...estimates.map(e => e.results.gpusRequired.toString())],
       ['TP size', ...estimates.map(e => e.results.tpSize.toString())],
+      ['PP size', ...estimates.map(e => e.results.ppSize.toString())],
       ['Replicas', ...estimates.map(e => e.results.replicas.toString())],
       ['', ...estimates.map(() => '')], // Separator
       ['Self-hosted (5yr)', ...estimates.map(e => `$${(e.results.selfHostedCost5Year / 1000).toFixed(0)}K`)],
@@ -411,6 +412,11 @@ export default function ComparePage() {
                 label="TP size"
                 estimates={estimates}
                 getValue={(e) => e.results.tpSize}
+              />
+              <ComparisonRow
+                label="PP size"
+                estimates={estimates}
+                getValue={(e) => e.results.ppSize}
               />
               <ComparisonRow
                 label="Replicas"

--- a/app/compare/page.tsx
+++ b/app/compare/page.tsx
@@ -35,6 +35,7 @@ const MOCK_DATA: SavedEstimate[] = [
     results: {
       gpusRequired: 8,
       tpSize: 1,
+      ppSize: 1,
       replicas: 8,
       weightMemoryGB: 64,
       kvCachePerUserGB: 2.0,
@@ -66,6 +67,7 @@ const MOCK_DATA: SavedEstimate[] = [
     results: {
       gpusRequired: 4,
       tpSize: 2,
+      ppSize: 1,
       replicas: 2,
       weightMemoryGB: 140,
       kvCachePerUserGB: 2.5,
@@ -97,6 +99,7 @@ const MOCK_DATA: SavedEstimate[] = [
     results: {
       gpusRequired: 8,
       tpSize: 1,
+      ppSize: 1,
       replicas: 8,
       weightMemoryGB: 62,
       kvCachePerUserGB: 0.054,
@@ -128,6 +131,7 @@ const MOCK_DATA: SavedEstimate[] = [
     results: {
       gpusRequired: 1,
       tpSize: 1,
+      ppSize: 1,
       replicas: 1,
       weightMemoryGB: 64,
       kvCachePerUserGB: 0.497,

--- a/app/performance/PerformanceEstimate.tsx
+++ b/app/performance/PerformanceEstimate.tsx
@@ -1549,7 +1549,7 @@ export default function QuickEstimate() {
         <div className={styles.card} style={{ marginBottom: 20 }}>
           <div className={styles.cardHead}>
             <span className={styles.cardTitle}>Memory layout per GPU</span>
-            <span className={styles.cardHint}>{memUsablePerGpu.toFixed(0)} GB usable · {testResult.memory_analysis.tp_size} GPU{testResult.memory_analysis.tp_size > 1 ? 's' : ''} per model instance</span>
+            <span className={styles.cardHint}>{memUsablePerGpu.toFixed(0)} GB usable · {testResult.memory_analysis.tp_size * (testResult.parallelism_strategy.pp_size || 1)} GPU{testResult.memory_analysis.tp_size * (testResult.parallelism_strategy.pp_size || 1) > 1 ? 's' : ''} per model instance</span>
           </div>
           <div className={styles.cardBody}>
             <div style={{ marginBottom: '12px' }}>
@@ -1575,7 +1575,7 @@ export default function QuickEstimate() {
                 </div>
                 {/* KV Cache */}
                 <div style={{
-                  width: `${((testResult.memory_analysis.kv_cache_used_gb || 0) / testResult.memory_analysis.tp_size / memUsablePerGpu) * 100}%`,
+                  width: `${((testResult.memory_analysis.kv_cache_used_gb || 0) / (testResult.memory_analysis.tp_size * (testResult.parallelism_strategy.pp_size || 1)) / memUsablePerGpu) * 100}%`,
                   background: '#f59e0b',
                   display: 'flex',
                   alignItems: 'center',
@@ -1607,7 +1607,7 @@ export default function QuickEstimate() {
               </span>
               <span>
                 <span style={{ display: 'inline-block', width: '12px', height: '12px', background: '#f59e0b', marginRight: '6px', borderRadius: '2px' }}></span>
-                KV Cache: <strong>{((testResult.memory_analysis.kv_cache_used_gb || 0) / testResult.memory_analysis.replicas).toFixed(1)} GB</strong>
+                KV Cache: <strong>{((testResult.memory_analysis.kv_cache_used_gb || 0) / (testResult.memory_analysis.tp_size * (testResult.parallelism_strategy.pp_size || 1))).toFixed(1)} GB</strong>
               </span>
               <span>
                 <span style={{ display: 'inline-block', width: '12px', height: '12px', background: '#e0e0e0', marginRight: '6px', borderRadius: '2px' }}></span>

--- a/app/performance/PerformanceEstimate.tsx
+++ b/app/performance/PerformanceEstimate.tsx
@@ -288,7 +288,10 @@ export default function QuickEstimate() {
     const timer = setTimeout(async () => {
       try {
         const spec = modelSpecs.get(model)
-        const isMoe = (spec?.num_experts ?? 0) > 1
+        // Check both catalog metadata and HF config for MoE detection
+        const catalogExperts = spec?.num_experts ?? 0
+        const hfExperts = (hfConfig?.num_experts as number) ?? (hfConfig?.num_local_experts as number) ?? 0
+        const isMoe = catalogExperts > 1 || hfExperts > 1
 
         const result = await fetchEstimateAsInferenceResult({
           model_path: model,
@@ -625,11 +628,19 @@ export default function QuickEstimate() {
     const ppFlag = testResult.parallelism_strategy.pp_size > 1
       ? ` \\\n  --pipeline-parallel-size ${testResult.parallelism_strategy.pp_size}`
       : '';
+
+    // Only FP16/FP8 are valid --dtype values; quantized modes use --quantization
+    const dtypeValue = testWeightPrecision === 'FP16' ? 'float16' :
+                       testWeightPrecision === 'FP8' ? 'fp8' : 'auto';
+    const quantFlag = (testWeightPrecision === 'INT4' || testWeightPrecision === 'INT8' || testWeightPrecision === 'MXFP4')
+      ? ` \\\n  --quantization ${testResult.vllm_config.quantization}`
+      : '';
+
     const cliCommand = `vllm serve ${model} \\
   --tensor-parallel-size ${testResult.memory_analysis.tp_size}${ppFlag} \\
   --max-model-len auto \\
   --gpu-memory-utilization 0.90 \\
-  --dtype ${testWeightPrecision.toLowerCase()} \\
+  --dtype ${dtypeValue}${quantFlag} \\
   --kv-cache-dtype ${testKVCachePrecision.toLowerCase()} \\
   --max-num-seqs ${testResult.vllm_config?.max_num_seqs || 256}${testResult.vllm_config?.enable_chunked_prefill ? ' \\\n  --enable-chunked-prefill' : ''}`;
 
@@ -725,7 +736,10 @@ export default function QuickEstimate() {
   // Build accordion sections dynamically from current state
   const buildAccordionSections = () => {
     const spec = modelSpecs.get(model);
-    const isMoeModel = (spec?.num_experts ?? 0) > 1;
+    // Check both catalog metadata and HF config for MoE detection
+    const catalogExperts = spec?.num_experts ?? 0;
+    const hfExperts = (hfConfig?.num_experts as number) ?? (hfConfig?.num_local_experts as number) ?? 0;
+    const isMoeModel = catalogExperts > 1 || hfExperts > 1;
 
     return [
     {
@@ -791,7 +805,11 @@ export default function QuickEstimate() {
           type: 'select' as const,
           term: 'weightPrecision',
           options: ['FP16', 'FP8', 'INT8', 'INT4', 'MXFP4'] as const,
-          onChange: (val: string) => setTestWeightPrecision(val as any)
+          onChange: (val: string) => {
+            if (val === 'FP16' || val === 'FP8' || val === 'INT8' || val === 'INT4' || val === 'MXFP4') {
+              setTestWeightPrecision(val);
+            }
+          }
         },
         {
           label: 'KV cache precision',
@@ -799,7 +817,11 @@ export default function QuickEstimate() {
           type: 'select' as const,
           term: 'kvCachePrecision',
           options: ['FP16', 'FP8'] as const,
-          onChange: (val: string) => setTestKVCachePrecision(val as any)
+          onChange: (val: string) => {
+            if (val === 'FP16' || val === 'FP8') {
+              setTestKVCachePrecision(val);
+            }
+          }
         },
         ...(isMoeModel ? [{
           label: 'MoE quantization',
@@ -812,7 +834,12 @@ export default function QuickEstimate() {
             { value: 'w4a16_mxfp4_cutlass', label: 'W4A16 MXFP4 (CUTLASS)' },
             { value: 'w4a8_mxfp4_mxfp8_trtllm', label: 'W4A8 MXFP4+FP8 (TRT-LLM)' }
           ],
-          onChange: (val: string) => setTestMoeQuantMode(val as any),
+          onChange: (val: string) => {
+            if (val === 'w4a16_mxfp4' || val === 'w4a8_mxfp4_mxfp8' ||
+                val === 'w4a16_mxfp4_cutlass' || val === 'w4a8_mxfp4_mxfp8_trtllm') {
+              setTestMoeQuantMode(val);
+            }
+          },
           help: 'W4A16: best quality, H100+. W4A8: ~2× faster on B200. CUTLASS: H100-optimized. TRT-LLM: B200 TRT-LLM variant.'
         }] : []),
       ],

--- a/app/performance/PerformanceEstimate.tsx
+++ b/app/performance/PerformanceEstimate.tsx
@@ -155,19 +155,22 @@ export default function QuickEstimate() {
   const [testTpSize, setTestTpSize] = React.useState(1);
   const [calcTrigger, setCalcTrigger] = React.useState(0);
   const [elapsed, setElapsed] = React.useState(0);
-  const [testWeightPrecision, setTestWeightPrecision] = React.useState<'FP16' | 'FP8' | 'INT8' | 'INT4'>('FP16');
-  const [testKVCachePrecision, setTestKVCachePrecision] = React.useState<'FP16' | 'FP8'>('FP16');44
+  const [testWeightPrecision, setTestWeightPrecision] = React.useState<'FP16' | 'FP8' | 'INT8' | 'INT4' | 'MXFP4'>('FP16');
+  const [testKVCachePrecision, setTestKVCachePrecision] = React.useState<'FP16' | 'FP8'>('FP16');
+  const [testPpSize, setTestPpSize] = React.useState(1);
   
   const [islInput, setIslInput] = React.useState('2048');
   const [oslInput, setOslInput] = React.useState('128');
   const [concurrentUsersInput, setConcurrentUsersInput] = React.useState('32');
   const [prefixInput, setPrefixInput] = React.useState('0');
   const [tpSizeInput, setTpSizeInput] = React.useState('1');
+  const [ppSizeInput, setPpSizeInput] = React.useState('1');
 
   const invalidISL = islInput === '' || parseInt(islInput, 10) < 1;
   const invalidOSL = oslInput === '' || parseInt(oslInput, 10) < 1;
   const invalidUsers = concurrentUsersInput === '' || parseInt(concurrentUsersInput, 10) < 1;
   const invalidTpSize = tpSizeInput === '' || parseInt(tpSizeInput, 10) < 1;
+  const invalidPpSize = ppSizeInput === '' || parseInt(ppSizeInput, 10) < 1;
 
   const handleIslChange = (raw: string) => {
     const digits = raw.replace(/[^0-9]/g, '');
@@ -195,6 +198,13 @@ export default function QuickEstimate() {
     setTpSizeInput(digits);
     const n = parseInt(digits, 10);
     if (!isNaN(n) && n >= 1) setTestTpSize(n);
+  };
+
+  const handlePpSizeChange = (raw: string) => {
+    const digits = raw.replace(/[^0-9]/g, '');
+    setPpSizeInput(digits);
+    const n = parseInt(digits, 10);
+    if (!isNaN(n) && n >= 1) setTestPpSize(n);
   };
 
   const handlePrefixChange = (raw: string) => {
@@ -285,6 +295,7 @@ export default function QuickEstimate() {
           osl: testOSL,
           batch_size: testConcurrentUsers,
           tp_size: testTpSize,
+          pp_size: testPpSize,
           backend: inferenceBackend,
           prefix: testPrefix > 0 ? testPrefix : undefined,
           vram_gb: currentAicGpu?.vramGb ?? null,
@@ -292,7 +303,10 @@ export default function QuickEstimate() {
           backend_version: backendVersion || undefined,
           hf_model_config: hfConfig as Record<string, unknown> | null,
           kvcache_quant_mode: testKVCachePrecision === 'FP8' ? 'fp8' : null,
-          gemm_quant_mode: testWeightPrecision === 'FP8' ? 'fp8' : testWeightPrecision === 'INT8' ? 'int8' : testWeightPrecision === 'INT4' ? 'int4' : null,
+          gemm_quant_mode: testWeightPrecision === 'FP8' ? 'fp8' :
+                          testWeightPrecision === 'INT8' ? 'int8_wo' :
+                          testWeightPrecision === 'INT4' ? 'int4_wo' :
+                          testWeightPrecision === 'MXFP4' ? 'int4_wo' : null,  // MXFP4 → int4_wo for non-MoE
           ...(isMoe && { moe_ep_size: testTpSize }),
         });
         if (!cancelled) {
@@ -418,7 +432,7 @@ export default function QuickEstimate() {
   // animated headline numbers
   // Calculate real values from inference engine
   const realGpuCount = testResult ?
-    testResult.memory_analysis.tp_size * testResult.memory_analysis.replicas :
+    testResult.memory_analysis.tp_size * testResult.memory_analysis.replicas * (testResult.parallelism_strategy.pp_size || 1) :
     0;
 
   const realWeightGB = testResult ?
@@ -443,6 +457,7 @@ export default function QuickEstimate() {
     if (method.includes('fp8') || method === 'fp8') return 'FP8';
     if (method.includes('int8') || method === 'int8') return 'INT8';
     if (method.includes('int4') || method === 'int4') return 'INT4';
+    if (method.includes('mxfp4') || method === 'mxfp4') return 'MXFP4';
     if (method === 'gptq' || method === 'awq') {
       // Check bits field for GPTQ/AWQ
       const bits = qconfig.bits || qconfig.num_bits || 4;
@@ -539,6 +554,7 @@ export default function QuickEstimate() {
       results: {
         gpusRequired: realGpuCount,
         tpSize: testResult.memory_analysis.tp_size,
+        ppSize: testResult.parallelism_strategy.pp_size,
         replicas: testResult.memory_analysis.replicas,
         weightMemoryGB: testResult.memory_analysis.weight_gb,
         kvCachePerUserGB: kvPerUserGB,
@@ -563,7 +579,7 @@ export default function QuickEstimate() {
   const handleCopyAPIRequest = async () => {
     if (!testResult) return;
 
-    const apiRequest = {
+    const apiRequest: Record<string, unknown> = {
       model: {
         model_id: model,
         max_model_len: 'auto'
@@ -585,6 +601,10 @@ export default function QuickEstimate() {
       }
     };
 
+    if (testResult.parallelism_strategy.pp_size > 1) {
+      (apiRequest.gpu as Record<string, unknown>).pp_size = testResult.parallelism_strategy.pp_size;
+    }
+
     try {
       await navigator.clipboard.writeText(JSON.stringify(apiRequest, null, 2));
       setToastMessage('api-copied');
@@ -599,8 +619,11 @@ export default function QuickEstimate() {
   const handleCopyCLICommand = async () => {
     if (!testResult) return;
 
+    const ppFlag = testResult.parallelism_strategy.pp_size > 1
+      ? ` \\\n  --pipeline-parallel-size ${testResult.parallelism_strategy.pp_size}`
+      : '';
     const cliCommand = `vllm serve ${model} \\
-  --tensor-parallel-size ${testResult.memory_analysis.tp_size} \\
+  --tensor-parallel-size ${testResult.memory_analysis.tp_size}${ppFlag} \\
   --max-model-len auto \\
   --gpu-memory-utilization 0.90 \\
   --dtype ${testWeightPrecision.toLowerCase()} \\
@@ -623,7 +646,7 @@ export default function QuickEstimate() {
 
     // Prepare data in CSV format
     const headers = [
-      'Model', 'GPU', 'GPUs Required', 'TP Size', 'Replicas',
+      'Model', 'GPU', 'GPUs Required', 'TP Size', 'PP Size', 'Replicas',
       'ISL', 'OSL', 'Concurrent Users',
       'Weight Precision', 'KV Cache Precision',
       'Weight Memory (GB)', 'KV Cache Total (GB)', 'KV Category',
@@ -632,7 +655,7 @@ export default function QuickEstimate() {
     ];
 
     const values = [
-      model, gpu, realGpuCount, testResult.memory_analysis.tp_size, testResult.memory_analysis.replicas,
+      model, gpu, realGpuCount, testResult.memory_analysis.tp_size, testResult.parallelism_strategy.pp_size, testResult.memory_analysis.replicas,
       testISL, testOSL, testConcurrentUsers,
       testWeightPrecision, testKVCachePrecision,
       testResult.memory_analysis.weight_gb.toFixed(1),
@@ -753,7 +776,7 @@ export default function QuickEstimate() {
             'Weight precision (overridden by model quantization_config)' : 'Weight precision',
           value: testWeightPrecision,
           type: 'select' as const,
-          options: ['FP16', 'FP8', 'INT8', 'INT4'] as const,
+          options: ['FP16', 'FP8', 'INT8', 'INT4', 'MXFP4'] as const,
           onChange: (val: string) => setTestWeightPrecision(val as any)
         },
         {
@@ -789,10 +812,11 @@ export default function QuickEstimate() {
       },
       summary: [
         { k: 'TP', v: `${testTpSize}` },
+        { k: 'PP', v: `${testPpSize}` },
       ],
       fields: [
         {
-          label: 'Tensor parallel size',
+          label: 'Tensor parallel size (TP)',
           value: tpSizeInput,
           term: 'tensorParallel',
           readonly: false,
@@ -801,8 +825,16 @@ export default function QuickEstimate() {
           onChange: (val: string) => handleTpSizeChange(val),
         },
         {
+          label: 'Pipeline parallel size (PP)',
+          value: ppSizeInput,
+          readonly: false,
+          type: 'number' as const,
+          invalid: invalidPpSize,
+          onChange: (val: string) => handlePpSizeChange(val),
+        },
+        {
           label: 'Total GPUs',
-          value: testResult ? `${testResult.memory_analysis.tp_size * testResult.memory_analysis.replicas}` : `${tpSizeInput}`,
+          value: testResult ? `${testResult.memory_analysis.tp_size * testResult.memory_analysis.replicas * testResult.parallelism_strategy.pp_size}` : `${parseInt(tpSizeInput || '1') * parseInt(ppSizeInput || '1')}`,
           readonly: true,
         },
       ],
@@ -951,7 +983,7 @@ export default function QuickEstimate() {
             variant="primary"
             size="lg"
             onClick={() => { setTestResult(null); setCalcTrigger(t => t + 1); }}
-            isDisabled={isCalculating || !gpu || !model || catalogLoading || invalidISL || invalidOSL || invalidUsers || invalidTpSize}
+            isDisabled={isCalculating || !gpu || !model || catalogLoading || invalidISL || invalidOSL || invalidUsers || invalidTpSize || invalidPpSize}
           >
             {isCalculating ? 'Calculating...' : 'Calculate'}
           </Button>
@@ -1128,7 +1160,7 @@ export default function QuickEstimate() {
               <span className={styles.tileValue}>{Math.round(gpus)}<span className={styles.tileUnit}>× {gpu}</span></span>
               <span className={styles.tileSub}>
                 {testResult ? (
-                  <>TP={testResult.memory_analysis.tp_size} × {testResult.memory_analysis.replicas} replica{testResult.memory_analysis.replicas > 1 ? 's' : ''} · {testConcurrentUsers} concurrent users</>
+                  <>TP={testResult.memory_analysis.tp_size}{testResult.parallelism_strategy.pp_size > 1 ? ` × PP=${testResult.parallelism_strategy.pp_size}` : ''} × {testResult.memory_analysis.replicas} replica{testResult.memory_analysis.replicas > 1 ? 's' : ''} · {testConcurrentUsers} concurrent users</>
                 ) : (
                   <>Configure workload below to see results</>
                 )}
@@ -1144,8 +1176,11 @@ export default function QuickEstimate() {
                     weight memory = <span className={styles.em}>{testResult.memory_analysis.weight_gb.toFixed(1)} GB</span><br />
                     usable / GPU = <span className={styles.em}>{memUsablePerGpu.toFixed(0)} GB</span><br />
                     TP size = ⌈{testResult.memory_analysis.weight_gb.toFixed(0)} ÷ {memUsablePerGpu.toFixed(0)}⌉ = <span className={styles.em}>{testResult.memory_analysis.tp_size}</span><br />
+                    {testResult.parallelism_strategy.pp_size > 1 && (
+                      <>PP size = <span className={styles.em}>{testResult.parallelism_strategy.pp_size}</span><br /></>
+                    )}
                     replicas = {testResult.memory_analysis.replicas}<br />
-                    total = <span className={styles.em}>{Math.round(gpus)} GPUs</span>
+                    total = {testResult.parallelism_strategy.pp_size > 1 ? `${testResult.memory_analysis.tp_size}×${testResult.parallelism_strategy.pp_size}×${testResult.memory_analysis.replicas}` : `${testResult.memory_analysis.tp_size}×${testResult.memory_analysis.replicas}`} = <span className={styles.em}>{Math.round(gpus)} GPUs</span>
                   </>
                 ) : (
                   <>
@@ -1186,7 +1221,8 @@ export default function QuickEstimate() {
                     bytes/param = <span className={styles.em}>
                       {actualWeightPrecision === 'FP16' ? '2' :
                        actualWeightPrecision === 'FP8' ? '1' :
-                       actualWeightPrecision === 'INT8' ? '1' : '0.5'}
+                       actualWeightPrecision === 'INT8' ? '1' :
+                       actualWeightPrecision === 'MXFP4' ? '0.5' : '0.5'}
                     </span><br />
                     params × bytes/param<br />
                     = <span className={styles.em}>{testResult.memory_analysis.weight_gb.toFixed(1)} GB</span>
@@ -1413,7 +1449,10 @@ export default function QuickEstimate() {
                       • Weight memory: <strong>{testResult.memory_analysis.weight_gb.toFixed(1)} GB</strong> ({actualWeightPrecision})<br/>
                       • Weight per GPU: <strong>{testResult.memory_analysis.weight_gb_per_gpu.toFixed(1)} GB</strong><br/>
                       • Usable per GPU: <strong>{memUsablePerGpu.toFixed(0)} GB</strong> (90% of {gpu.includes('H200') ? '141' : '80'} GB)<br/>
-                      • Tensor Parallel size: <strong>{testResult.memory_analysis.tp_size}</strong> {testResult.memory_analysis.weight_gb > memUsablePerGpu ? '(required - weights don\'t fit in 1 GPU)' : '(weights fit, but using for replicas)'}
+                      • Tensor Parallel size: <strong>{testResult.memory_analysis.tp_size}</strong> {testResult.memory_analysis.weight_gb > memUsablePerGpu ? '(required - weights don\'t fit in 1 GPU)' : '(weights fit, but using for replicas)'}<br/>
+                      {testResult.parallelism_strategy.pp_size > 1 && (
+                        <>• Pipeline Parallel size: <strong>{testResult.parallelism_strategy.pp_size}</strong> (splits model layers across pipeline stages)<br/></>
+                      )}
                     </div>
                   </div>
 

--- a/app/performance/PerformanceEstimate.tsx
+++ b/app/performance/PerformanceEstimate.tsx
@@ -157,6 +157,7 @@ export default function QuickEstimate() {
   const [elapsed, setElapsed] = React.useState(0);
   const [testWeightPrecision, setTestWeightPrecision] = React.useState<'FP16' | 'FP8' | 'INT8' | 'INT4' | 'MXFP4'>('FP16');
   const [testKVCachePrecision, setTestKVCachePrecision] = React.useState<'FP16' | 'FP8'>('FP16');
+  const [testMoeQuantMode, setTestMoeQuantMode] = React.useState<'w4a16_mxfp4' | 'w4a8_mxfp4_mxfp8' | 'w4a16_mxfp4_cutlass' | 'w4a8_mxfp4_mxfp8_trtllm'>('w4a16_mxfp4');
   const [testPpSize, setTestPpSize] = React.useState(1);
   
   const [islInput, setIslInput] = React.useState('2048');
@@ -288,6 +289,10 @@ export default function QuickEstimate() {
       try {
         const spec = modelSpecs.get(model)
         const isMoe = (spec?.num_experts ?? 0) > 1
+
+        // For MoE models with MXFP4, use moe_quant_mode instead of gemm_quant_mode
+        const useMoeQuant = isMoe && testWeightPrecision === 'MXFP4'
+
         const result = await fetchEstimateAsInferenceResult({
           model_path: model,
           system: systemId,
@@ -303,10 +308,13 @@ export default function QuickEstimate() {
           backend_version: backendVersion || undefined,
           hf_model_config: hfConfig as Record<string, unknown> | null,
           kvcache_quant_mode: testKVCachePrecision === 'FP8' ? 'fp8' : null,
-          gemm_quant_mode: testWeightPrecision === 'FP8' ? 'fp8' :
-                          testWeightPrecision === 'INT8' ? 'int8_wo' :
-                          testWeightPrecision === 'INT4' ? 'int4_wo' :
-                          testWeightPrecision === 'MXFP4' ? 'int4_wo' : null,  // MXFP4 → int4_wo for non-MoE
+          gemm_quant_mode: useMoeQuant ? null : (
+            testWeightPrecision === 'FP8' ? 'fp8' :
+            testWeightPrecision === 'INT8' ? 'int8_wo' :
+            testWeightPrecision === 'INT4' ? 'int4_wo' :
+            testWeightPrecision === 'MXFP4' ? 'int4_wo' : null
+          ),
+          moe_quant_mode: useMoeQuant ? testMoeQuantMode : undefined,
           ...(isMoe && { moe_ep_size: testTpSize }),
         });
         if (!cancelled) {
@@ -720,7 +728,11 @@ export default function QuickEstimate() {
   const validationWarnings = getValidationWarnings();
 
   // Build accordion sections dynamically from current state
-  const buildAccordionSections = () => [
+  const buildAccordionSections = () => {
+    const spec = modelSpecs.get(model);
+    const isMoeModel = (spec?.num_experts ?? 0) > 1;
+
+    return [
     {
       id: 'workload', title: 'Workload',
       summary: [
@@ -768,7 +780,8 @@ export default function QuickEstimate() {
       id: 'memory', title: 'Precision & memory',
       summary: [
         { k: 'weights', v: actualWeightPrecision },
-        { k: 'KV', v: testKVCachePrecision }
+        { k: 'KV', v: testKVCachePrecision },
+        ...(isMoeModel && testWeightPrecision === 'MXFP4' ? [{ k: 'MoE', v: testMoeQuantMode }] : [])
       ],
       fields: [
         {
@@ -786,6 +799,14 @@ export default function QuickEstimate() {
           options: ['FP16', 'FP8'] as const,
           onChange: (val: string) => setTestKVCachePrecision(val as any)
         },
+        ...(isMoeModel && testWeightPrecision === 'MXFP4' ? [{
+          label: 'MoE quantization mode',
+          value: testMoeQuantMode,
+          type: 'select' as const,
+          options: ['w4a16_mxfp4', 'w4a8_mxfp4_mxfp8', 'w4a16_mxfp4_cutlass', 'w4a8_mxfp4_mxfp8_trtllm'] as const,
+          onChange: (val: string) => setTestMoeQuantMode(val as any),
+          help: 'w4a16: best quality, works on H100+. w4a8: ~2× faster on B200. cutlass: H100-optimized. trtllm: B200 TRT-LLM variant.'
+        }] : []),
       ],
     },
     {
@@ -918,6 +939,7 @@ export default function QuickEstimate() {
       ],
     },
   ];
+  };
 
   return (
     <div className={styles.page}>
@@ -1646,15 +1668,22 @@ export default function QuickEstimate() {
                         {f.readonly ? (
                           <TextInput value={String(f.value)} aria-label={f.label} isDisabled />
                         ) : f.type === 'select' ? (
-                          <FormSelect
-                            value={String(f.value)}
-                            aria-label={f.label}
-                            onChange={(_, val) => f.onChange?.(val)}
-                          >
-                            {(f.options || [f.value]).map((o: any) => (
-                              <FormSelectOption key={o} value={o} label={o} />
-                            ))}
-                          </FormSelect>
+                          <>
+                            <FormSelect
+                              value={String(f.value)}
+                              aria-label={f.label}
+                              onChange={(_, val) => f.onChange?.(val)}
+                            >
+                              {(f.options || [f.value]).map((o: any) => (
+                                <FormSelectOption key={o} value={o} label={o} />
+                              ))}
+                            </FormSelect>
+                            {f.help && (
+                              <div style={{ fontSize: '12px', color: '#6a6e73', marginTop: '4px', lineHeight: '1.5' }}>
+                                {f.help}
+                              </div>
+                            )}
+                          </>
                         ) : f.type === 'range' ? (
                           <div>
                             <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '4px' }}>

--- a/app/performance/PerformanceEstimate.tsx
+++ b/app/performance/PerformanceEstimate.tsx
@@ -290,9 +290,6 @@ export default function QuickEstimate() {
         const spec = modelSpecs.get(model)
         const isMoe = (spec?.num_experts ?? 0) > 1
 
-        // For MoE models with MXFP4, use moe_quant_mode instead of gemm_quant_mode
-        const useMoeQuant = isMoe && testWeightPrecision === 'MXFP4'
-
         const result = await fetchEstimateAsInferenceResult({
           model_path: model,
           system: systemId,
@@ -308,13 +305,11 @@ export default function QuickEstimate() {
           backend_version: backendVersion || undefined,
           hf_model_config: hfConfig as Record<string, unknown> | null,
           kvcache_quant_mode: testKVCachePrecision === 'FP8' ? 'fp8' : null,
-          gemm_quant_mode: useMoeQuant ? null : (
-            testWeightPrecision === 'FP8' ? 'fp8' :
-            testWeightPrecision === 'INT8' ? 'int8_wo' :
-            testWeightPrecision === 'INT4' ? 'int4_wo' :
-            testWeightPrecision === 'MXFP4' ? 'int4_wo' : null
-          ),
-          moe_quant_mode: useMoeQuant ? testMoeQuantMode : undefined,
+          gemm_quant_mode: testWeightPrecision === 'FP8' ? 'fp8' :
+                          testWeightPrecision === 'INT8' ? 'int8_wo' :
+                          testWeightPrecision === 'INT4' ? 'int4_wo' :
+                          testWeightPrecision === 'MXFP4' ? 'mxfp4' : null,
+          moe_quant_mode: isMoe ? testMoeQuantMode : undefined,
           ...(isMoe && { moe_ep_size: testTpSize }),
         });
         if (!cancelled) {
@@ -781,7 +776,12 @@ export default function QuickEstimate() {
       summary: [
         { k: 'weights', v: actualWeightPrecision },
         { k: 'KV', v: testKVCachePrecision },
-        ...(isMoeModel && testWeightPrecision === 'MXFP4' ? [{ k: 'MoE', v: testMoeQuantMode }] : [])
+        ...(isMoeModel ? [{
+          k: 'MoE',
+          v: testMoeQuantMode === 'w4a16_mxfp4' ? 'W4A16' :
+             testMoeQuantMode === 'w4a8_mxfp4_mxfp8' ? 'W4A8' :
+             testMoeQuantMode === 'w4a16_mxfp4_cutlass' ? 'CUTLASS' : 'TRT-LLM'
+        }] : [])
       ],
       fields: [
         {
@@ -799,13 +799,18 @@ export default function QuickEstimate() {
           options: ['FP16', 'FP8'] as const,
           onChange: (val: string) => setTestKVCachePrecision(val as any)
         },
-        ...(isMoeModel && testWeightPrecision === 'MXFP4' ? [{
-          label: 'MoE quantization mode',
+        ...(isMoeModel ? [{
+          label: 'MoE quantization',
           value: testMoeQuantMode,
           type: 'select' as const,
-          options: ['w4a16_mxfp4', 'w4a8_mxfp4_mxfp8', 'w4a16_mxfp4_cutlass', 'w4a8_mxfp4_mxfp8_trtllm'] as const,
+          options: [
+            { value: 'w4a16_mxfp4', label: 'W4A16 MXFP4' },
+            { value: 'w4a8_mxfp4_mxfp8', label: 'W4A8 MXFP4+FP8' },
+            { value: 'w4a16_mxfp4_cutlass', label: 'W4A16 MXFP4 (CUTLASS)' },
+            { value: 'w4a8_mxfp4_mxfp8_trtllm', label: 'W4A8 MXFP4+FP8 (TRT-LLM)' }
+          ],
           onChange: (val: string) => setTestMoeQuantMode(val as any),
-          help: 'w4a16: best quality, works on H100+. w4a8: ~2× faster on B200. cutlass: H100-optimized. trtllm: B200 TRT-LLM variant.'
+          help: 'W4A16: best quality, H100+. W4A8: ~2× faster on B200. CUTLASS: H100-optimized. TRT-LLM: B200 TRT-LLM variant.'
         }] : []),
       ],
     },
@@ -1674,9 +1679,11 @@ export default function QuickEstimate() {
                               aria-label={f.label}
                               onChange={(_, val) => f.onChange?.(val)}
                             >
-                              {(f.options || [f.value]).map((o: any) => (
-                                <FormSelectOption key={o} value={o} label={o} />
-                              ))}
+                              {(f.options || [f.value]).map((o: any) => {
+                                const optValue = typeof o === 'string' ? o : o.value;
+                                const optLabel = typeof o === 'string' ? o : o.label;
+                                return <FormSelectOption key={optValue} value={optValue} label={optLabel} />;
+                              })}
                             </FormSelect>
                             {f.help && (
                               <div style={{ fontSize: '12px', color: '#6a6e73', marginTop: '4px', lineHeight: '1.5' }}>

--- a/app/performance/PerformanceEstimate.tsx
+++ b/app/performance/PerformanceEstimate.tsx
@@ -789,6 +789,7 @@ export default function QuickEstimate() {
             'Weight precision (overridden by model quantization_config)' : 'Weight precision',
           value: testWeightPrecision,
           type: 'select' as const,
+          term: 'weightPrecision',
           options: ['FP16', 'FP8', 'INT8', 'INT4', 'MXFP4'] as const,
           onChange: (val: string) => setTestWeightPrecision(val as any)
         },
@@ -796,6 +797,7 @@ export default function QuickEstimate() {
           label: 'KV cache precision',
           value: testKVCachePrecision,
           type: 'select' as const,
+          term: 'kvCachePrecision',
           options: ['FP16', 'FP8'] as const,
           onChange: (val: string) => setTestKVCachePrecision(val as any)
         },
@@ -803,6 +805,7 @@ export default function QuickEstimate() {
           label: 'MoE quantization',
           value: testMoeQuantMode,
           type: 'select' as const,
+          term: 'moeQuantization',
           options: [
             { value: 'w4a16_mxfp4', label: 'W4A16 MXFP4' },
             { value: 'w4a8_mxfp4_mxfp8', label: 'W4A8 MXFP4+FP8' },
@@ -853,6 +856,7 @@ export default function QuickEstimate() {
         {
           label: 'Pipeline parallel size (PP)',
           value: ppSizeInput,
+          term: 'pipelineParallel',
           readonly: false,
           type: 'number' as const,
           invalid: invalidPpSize,
@@ -909,6 +913,7 @@ export default function QuickEstimate() {
         {
           label: 'max_model_len',
           value: vllmOverride && vllmManualMaxModelLen !== null ? `${vllmManualMaxModelLen}` : testResult ? `${testResult.vllm_config.max_model_len}` : '—',
+          term: 'maxModelLen',
           readonly: !vllmOverride,
           type: vllmOverride ? 'number' as const : undefined,
           onChange: vllmOverride ? (val: string) => setVllmManualMaxModelLen(parseInt(val) || 1) : undefined
@@ -916,6 +921,7 @@ export default function QuickEstimate() {
         {
           label: 'enable_chunked_prefill',
           value: vllmOverride && vllmManualChunkedPrefill !== null ? (vllmManualChunkedPrefill ? 'Yes' : 'No') : testResult ? (testResult.vllm_config.enable_chunked_prefill ? 'Yes' : 'No') : '—',
+          term: 'chunkedPrefill',
           readonly: !vllmOverride,
           type: vllmOverride ? 'select' as const : undefined,
           options: vllmOverride ? ['Yes', 'No'] : undefined,
@@ -924,6 +930,7 @@ export default function QuickEstimate() {
         {
           label: 'enable_prefix_caching',
           value: vllmOverride && vllmManualPrefixCaching !== null ? (vllmManualPrefixCaching ? 'Yes' : 'No') : testResult ? (testResult.vllm_config.enable_prefix_caching ? 'Yes' : 'No') : '—',
+          term: 'prefixCaching',
           readonly: !vllmOverride,
           type: vllmOverride ? 'select' as const : undefined,
           options: vllmOverride ? ['Yes', 'No'] : undefined,

--- a/app/performance/quickEstimateHelpers.tsx
+++ b/app/performance/quickEstimateHelpers.tsx
@@ -51,6 +51,22 @@ export const GLOSSARY: Record<string, { title: string; body: string }> = {
     title: 'Tensor parallel size (TP)',
     body: 'How many GPUs a single model copy is split across. TP = 1 means the whole model fits on one GPU; larger models need TP = 2, 4, 8…',
   },
+  pipelineParallel: {
+    title: 'Pipeline parallel size (PP)',
+    body: 'How many GPUs to split the model layers across in a pipeline. PP = 1 means all layers on the same GPU(s). PP > 1 splits layers across GPUs for very large models. Total GPUs = TP × PP × replicas.',
+  },
+  maxModelLen: {
+    title: 'max_model_len',
+    body: 'Maximum total sequence length (input + output tokens) the engine will allow. Set to "auto" to use the model\'s native context window from its config. Lower values save KV cache memory.',
+  },
+  chunkedPrefill: {
+    title: 'enable_chunked_prefill',
+    body: 'When enabled, vLLM splits long prompts into chunks to avoid stalling decode (generation). Improves latency for mixed workloads with very long prompts. Recommended when ISL > 4096 or batch size > 64.',
+  },
+  prefixCaching: {
+    title: 'enable_prefix_caching',
+    body: 'When enabled, vLLM automatically detects and reuses shared prompt prefixes (e.g., system prompts). Saves compute and memory when many requests share the same prefix. Recommended when you have shared prefixes.',
+  },
   rangeDrivers: {
     title: 'Range drivers',
     body: 'The estimate is a range, not a single number, because real traffic varies. Range drivers are the assumptions that move the GPU count the most — tune these first to make the estimate match your reality.',
@@ -59,9 +75,25 @@ export const GLOSSARY: Record<string, { title: string; body: string }> = {
     title: 'Worst-case context',
     body: 'KV cache if every active request filled the model\'s entire context window (max_model_len) at the same time. A safety ceiling — most workloads never reach it.',
   },
+  prefix: {
+    title: 'Prefix length',
+    body: 'Number of tokens that are shared across requests (e.g., a system prompt). When prefix caching is enabled, these tokens are computed once and reused, saving memory and compute.',
+  },
   prefixCache: {
     title: 'Prefix-cache hit rate',
     body: 'Share of requests that reuse an already-computed prompt prefix (e.g. a shared system prompt). Higher hit rates reuse KV cache and cut memory.',
+  },
+  weightPrecision: {
+    title: 'Weight precision',
+    body: 'Number format for model parameters. FP16/BF16 = 2 bytes/param (full precision). FP8 = 1 byte (8-bit float). INT8 = 1 byte (8-bit integer). INT4 = 0.5 bytes (4-bit integer). MXFP4 = 0.5 bytes (Microscaling FP4). Lower precision reduces memory but may impact quality.',
+  },
+  kvCachePrecision: {
+    title: 'KV cache precision',
+    body: 'Number format for key-value cache vectors. FP16 = 2 bytes per element (standard). FP8 = 1 byte per element (half the memory, slight quality loss). Lower precision lets you fit more requests in the same memory.',
+  },
+  moeQuantization: {
+    title: 'MoE quantization mode',
+    body: 'Quantization strategy for Mixture-of-Experts models. W4A16 MXFP4 = 4-bit weights, 16-bit activations (best quality, H100+). W4A8 = 4-bit weights, 8-bit activations (~2× faster on B200, lower quality). CUTLASS = H100-optimized kernel. TRT-LLM = B200 TensorRT-LLM variant.',
   },
   gpuUtil: {
     title: 'GPU memory utilization',

--- a/lib/api/estimate-adapter.ts
+++ b/lib/api/estimate-adapter.ts
@@ -119,6 +119,12 @@ export async function fetchEstimateAsInferenceResult(
 
   const tp = data.tp ?? input.tp_size
   const pp = data.pp ?? input.pp_size ?? 1
+
+  // Validate PP is a positive integer before using it as a divisor
+  if (!Number.isSafeInteger(pp) || pp < 1) {
+    throw new EstimateError('INVALID_PP_SIZE', 'Pipeline parallel size must be a positive integer')
+  }
+
   const sc = data.serving_config
   const mb = data.memory_breakdown
   const totalVramGb = input.vram_gb ?? null

--- a/lib/api/estimate-adapter.ts
+++ b/lib/api/estimate-adapter.ts
@@ -118,7 +118,7 @@ export async function fetchEstimateAsInferenceResult(
   }
 
   const tp = data.tp ?? input.tp_size
-  const pp = data.pp ?? 1
+  const pp = data.pp ?? input.pp_size ?? 1
   const sc = data.serving_config
   const mb = data.memory_breakdown
   const totalVramGb = input.vram_gb ?? null
@@ -132,15 +132,18 @@ export async function fetchEstimateAsInferenceResult(
   const maxNumSeqs = sc?.max_num_seqs ?? input.batch_size
   const maxModelLen = sc?.max_model_len ?? (input.isl + input.osl)
 
+  // With pipeline parallel, weights are sharded across TP×PP GPUs
+  const shardCount = tp * pp
+
   return {
     memory_analysis: {
       weight_gb: weightGb,
-      weight_gb_per_gpu: weightGb / tp,
+      weight_gb_per_gpu: weightGb / shardCount,
       total_vram_gb: totalVramGb,
       usable_hbm_per_gpu: usablePerGpu,
       tp_size: tp,
       replicas: 1,
-      kv_cache_budget_gb: usablePerGpu != null ? usablePerGpu - weightGb / tp : null,
+      kv_cache_budget_gb: usablePerGpu != null ? usablePerGpu - weightGb / shardCount : null,
       kv_cache_used_gb: kvCacheGb,
       max_sequences_from_memory: maxNumSeqs,
       kv_category: 'AIC',

--- a/lib/api/estimate-adapter.ts
+++ b/lib/api/estimate-adapter.ts
@@ -34,6 +34,7 @@ export interface EstimateAdapterInput {
   hf_model_config?: Record<string, unknown> | null
   moe_ep_size?: number
   moe_tp_size?: number
+  moe_quant_mode?: string
   prefix?: number
   kvcache_quant_mode?: string | null
   gemm_quant_mode?: string | null
@@ -86,6 +87,7 @@ export async function fetchEstimateAsInferenceResult(
   if (input.prefix != null && input.prefix > 0) body.prefix = input.prefix
   if (input.kvcache_quant_mode) body.kvcache_quant_mode = input.kvcache_quant_mode
   if (input.gemm_quant_mode) body.gemm_quant_mode = input.gemm_quant_mode
+  if (input.moe_quant_mode) body.moe_quant_mode = input.moe_quant_mode
 
   if (input.hf_model_config) {
     body.model_config = input.hf_model_config

--- a/lib/api/estimate-adapter.ts
+++ b/lib/api/estimate-adapter.ts
@@ -26,6 +26,7 @@ export interface EstimateAdapterInput {
   osl: number
   batch_size: number
   tp_size: number
+  pp_size?: number
   vram_gb?: number | null
   gpu_memory_utilization?: number
   backend?: string
@@ -80,6 +81,7 @@ export async function fetchEstimateAsInferenceResult(
     tp_size: input.tp_size,
   }
 
+  if (input.pp_size != null && input.pp_size > 1) body.pp_size = input.pp_size
   if (input.backend_version) body.backend_version = input.backend_version
   if (input.prefix != null && input.prefix > 0) body.prefix = input.prefix
   if (input.kvcache_quant_mode) body.kvcache_quant_mode = input.kvcache_quant_mode

--- a/lib/gpu-math/inference-config/types.ts
+++ b/lib/gpu-math/inference-config/types.ts
@@ -5,7 +5,7 @@ import type { HFModelConfig } from '@/lib/huggingface/fetch-config'
 
 export interface InferenceRequest {
   model_name: string
-  precision: 'FP16' | 'FP8' | 'INT8' | 'INT4'  // Weight precision
+  precision: 'FP16' | 'FP8' | 'INT8' | 'INT4' | 'MXFP4'  // Weight precision
   gpu_type: string
   gpu_count?: number  // Optional - engine recommends if not provided
   concurrent_users: number

--- a/lib/saved-estimates.ts
+++ b/lib/saved-estimates.ts
@@ -37,20 +37,38 @@ export interface SavedEstimate {
 
 const STORAGE_KEY = 'gc-saved-estimates';
 
+function isValidEstimate(value: unknown): value is SavedEstimate {
+  if (typeof value !== 'object' || value === null) return false;
+  const obj = value as Record<string, unknown>;
+  return (
+    typeof obj.id === 'string' &&
+    typeof obj.name === 'string' &&
+    typeof obj.model === 'string' &&
+    typeof obj.gpu === 'string' &&
+    typeof obj.results === 'object' &&
+    obj.results !== null
+  );
+}
+
 export function getSavedEstimates(): SavedEstimate[] {
   if (typeof window === 'undefined') return [];
   try {
     const data = localStorage.getItem(STORAGE_KEY);
-    const estimates = data ? JSON.parse(data) : [];
+    if (!data) return [];
 
-    // Normalize legacy estimates: add ppSize=1 if missing
-    return estimates.map((est: SavedEstimate) => ({
-      ...est,
-      results: {
-        ...est.results,
-        ppSize: est.results.ppSize ?? 1
-      }
-    }));
+    const parsed: unknown = JSON.parse(data);
+    if (!Array.isArray(parsed)) return [];
+
+    // Validate and normalize: filter invalid entries, add ppSize=1 if missing
+    return parsed
+      .filter((item): item is SavedEstimate => isValidEstimate(item))
+      .map((est) => ({
+        ...est,
+        results: {
+          ...est.results,
+          ppSize: est.results.ppSize ?? 1
+        }
+      }));
   } catch (error) {
     console.error('Failed to load saved estimates:', error);
     return [];

--- a/lib/saved-estimates.ts
+++ b/lib/saved-estimates.ts
@@ -41,7 +41,16 @@ export function getSavedEstimates(): SavedEstimate[] {
   if (typeof window === 'undefined') return [];
   try {
     const data = localStorage.getItem(STORAGE_KEY);
-    return data ? JSON.parse(data) : [];
+    const estimates = data ? JSON.parse(data) : [];
+
+    // Normalize legacy estimates: add ppSize=1 if missing
+    return estimates.map((est: SavedEstimate) => ({
+      ...est,
+      results: {
+        ...est.results,
+        ppSize: est.results.ppSize ?? 1
+      }
+    }));
   } catch (error) {
     console.error('Failed to load saved estimates:', error);
     return [];

--- a/lib/saved-estimates.ts
+++ b/lib/saved-estimates.ts
@@ -20,6 +20,7 @@ export interface SavedEstimate {
   results: {
     gpusRequired: number;
     tpSize: number;
+    ppSize: number;
     replicas: number;
     weightMemoryGB: number;
     kvCachePerUserGB: number;


### PR DESCRIPTION
## Summary

Adds support for MXFP4 precision, Pipeline Parallel (PP) configuration, and MoE-specific quantization modes to the Performance Estimate page.

## Changes

### 🎯 Core Features

**MXFP4 Precision Support**
- Added MXFP4 to weight precision dropdown
- Sends `gemm_quant_mode: 'mxfp4'` to backend (future-proof for HuggingFace models)
- Auto-detects MXFP4 from model `quantization_config`

**Pipeline Parallel (PP) Support**
- Added PP size input field in Parallelism section
- Updated GPU calculations: `TP × PP × Replicas`
- Added PP to all displays (results, CLI commands, API exports, CSV)
- Includes PP in saved estimates

**MoE Quantization Modes**
- Always shown for MoE models (orthogonal to weight precision)
- Four hardware-optimized modes:
  - **W4A16 MXFP4** (default) - best quality, H100+
  - **W4A8 MXFP4+FP8** - ~2× faster on B200
  - **W4A16 MXFP4 (CUTLASS)** - H100-optimized kernel
  - **W4A8 MXFP4+FP8 (TRT-LLM)** - B200 TRT-LLM variant
- Human-readable labels with help text

### 🐛 Fixes

**INT4/INT8 API Parameter Mapping**
- Fixed: `int4` → `int4_wo` (weight-only)
- Fixed: `int8` → `int8_wo` (weight-only)
- Resolves backend API errors when using INT4/INT8 precision

### 📚 Documentation

**Added Glossary Tooltips**
- Prefix length
- Weight precision, KV cache precision, MoE quantization
- Pipeline parallel size
- max_model_len, enable_chunked_prefill, enable_prefix_caching

All fields now have "?" info icons with plain-language explanations.

## Use Cases

### Kimi K3 Configuration
```
Model: Moonshot/Kimi-K3
Weight Precision: MXFP4
MoE Quantization: W4A16 MXFP4
TP: 8
PP: 2
GPU: H200
Result: 16 GPUs (TP8 × PP2 × 1 replica)
```

### DeepSeek-V4 on B200
```
Model: deepseek-ai/DeepSeek-V4
Weight Precision: MXFP4
MoE Quantization: W4A8 MXFP4+FP8  (faster on B200)
```

## API Structure

Now properly mirrors AIConfigurator's 3-parameter structure:

1. **`gemm_quant_mode`** - Weight precision (FP16, FP8, INT8, INT4, MXFP4)
2. **`kvcache_quant_mode`** - KV cache precision (FP16, FP8)
3. **`moe_quant_mode`** - MoE-specific quantization (for MoE models)

## Testing

- ✅ TypeScript type checking passes
- ✅ Production build succeeds
- ✅ Dev server tested locally with Kimi K3 model
- ✅ All precision modes send correct API parameters
- ✅ PP size calculations correct
- ✅ MoE quant modes display for MoE models only

## Related Issues

Resolves issues reported by colleague:
- ✅ MXFP4 precision not available
- ✅ Cannot specify PP size for TP8×PP2 configurations
- ✅ INT4 gives API errors

## Commits

1. **feat(performance): add MXFP4 precision and Pipeline Parallel support**
2. **feat(performance): add MoE quantization mode selector**
3. **refactor(performance): decouple MoE quant from weight precision**
4. **docs(performance): add missing glossary tooltips**

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added pipeline-parallel sizing controls to performance estimates.
  - Added MoE quantization options, including MXFP4 precision support.
  - Updated GPU sizing, costs, saved estimates, exports, API requests, and CLI commands to reflect pipeline parallelism.
  - Added contextual help for performance settings.
- **Bug Fixes**
  - Improved comparison estimates by including pipeline-parallel sizing data.
  - Preserved existing saved estimates when pipeline-parallel data is unavailable.
- **Documentation**
  - Expanded glossary explanations for inference configuration and optimization options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->