### PR TITLE
fix(container): OpenShift compatibility for arbitrary UIDs

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -19,13 +19,14 @@ FROM node:20-alpine
 WORKDIR /app
 
 ENV NODE_ENV=production
-RUN addgroup -g 1001 -S configiq && adduser -S configiq -u 1001
 
-COPY --from=builder --chown=configiq:configiq /app/.next/standalone ./
-COPY --from=builder --chown=configiq:configiq /app/.next/static ./.next/static
-COPY --from=builder --chown=configiq:configiq /app/public ./public
+COPY --from=builder --chown=1001:0 /app/.next/standalone ./
+COPY --from=builder --chown=1001:0 /app/.next/static ./.next/static
+COPY --from=builder --chown=1001:0 /app/public ./public
 
-USER configiq
+RUN chmod -R g=u /app
+
+USER 1001
 
 EXPOSE 3000
 


### PR DESCRIPTION
## Summary

- Remove `adduser`/`addgroup` — OpenShift assigns arbitrary UIDs at runtime and can't modify `/etc/passwd`
- Use numeric UID `1001:0` for file ownership (group 0 required for OpenShift)
- Add `chmod -R g=u` for group write permissions (required for arbitrary UIDs)
- Change `USER` directive to numeric UID `1001`

This allows the container to run in OpenShift restricted SCC with arbitrary UIDs while maintaining full compatibility with podman/docker deployments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the runtime container to use a non-root numeric user.
  * Improved application file permissions for reliable runtime access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->