### PR TITLE
feat(performance): add NVFP4 precision support

### DIFF
--- a/app/performance/PerformanceEstimate.tsx
+++ b/app/performance/PerformanceEstimate.tsx
@@ -155,8 +155,8 @@ export default function QuickEstimate() {
   const [testTpSize, setTestTpSize] = React.useState(1);
   const [calcTrigger, setCalcTrigger] = React.useState(0);
   const [elapsed, setElapsed] = React.useState(0);
-  const [testWeightPrecision, setTestWeightPrecision] = React.useState<'FP16' | 'FP8' | 'INT8' | 'INT4' | 'MXFP4'>('FP16');
-  const [testKVCachePrecision, setTestKVCachePrecision] = React.useState<'FP16' | 'FP8'>('FP16');
+  const [testWeightPrecision, setTestWeightPrecision] = React.useState<'FP16' | 'FP8' | 'INT8' | 'INT4' | 'MXFP4' | 'NVFP4'>('FP16');
+  const [testKVCachePrecision, setTestKVCachePrecision] = React.useState<'FP16' | 'FP8' | 'NVFP4'>('FP16');
   const [testMoeQuantMode, setTestMoeQuantMode] = React.useState<'w4a16_mxfp4' | 'w4a8_mxfp4_mxfp8' | 'w4a16_mxfp4_cutlass' | 'w4a8_mxfp4_mxfp8_trtllm'>('w4a16_mxfp4');
   const [testPpSize, setTestPpSize] = React.useState(1);
   
@@ -307,11 +307,13 @@ export default function QuickEstimate() {
           gpu_memory_utilization: currentAicGpu?.gpuMemoryUtilization,
           backend_version: backendVersion || undefined,
           hf_model_config: hfConfig as Record<string, unknown> | null,
-          kvcache_quant_mode: testKVCachePrecision === 'FP8' ? 'fp8' : null,
+          kvcache_quant_mode: testKVCachePrecision === 'FP8' ? 'fp8' :
+                             testKVCachePrecision === 'NVFP4' ? 'nvfp4' : null,
           gemm_quant_mode: testWeightPrecision === 'FP8' ? 'fp8' :
                           testWeightPrecision === 'INT8' ? 'int8_wo' :
                           testWeightPrecision === 'INT4' ? 'int4_wo' :
-                          testWeightPrecision === 'MXFP4' ? 'mxfp4' : null,
+                          testWeightPrecision === 'MXFP4' ? 'mxfp4' :
+                          testWeightPrecision === 'NVFP4' ? 'nvfp4' : null,
           moe_quant_mode: isMoe ? testMoeQuantMode : undefined,
           ...(isMoe && { moe_ep_size: testTpSize }),
         });
@@ -632,7 +634,7 @@ export default function QuickEstimate() {
     // Only FP16/FP8 are valid --dtype values; quantized modes use --quantization
     const dtypeValue = testWeightPrecision === 'FP16' ? 'float16' :
                        testWeightPrecision === 'FP8' ? 'fp8' : 'auto';
-    const quantFlag = (testWeightPrecision === 'INT4' || testWeightPrecision === 'INT8' || testWeightPrecision === 'MXFP4')
+    const quantFlag = (testWeightPrecision === 'INT4' || testWeightPrecision === 'INT8' || testWeightPrecision === 'MXFP4' || testWeightPrecision === 'NVFP4')
       ? ` \\\n  --quantization ${testResult.vllm_config.quantization}`
       : '';
 
@@ -804,9 +806,9 @@ export default function QuickEstimate() {
           value: testWeightPrecision,
           type: 'select' as const,
           term: 'weightPrecision',
-          options: ['FP16', 'FP8', 'INT8', 'INT4', 'MXFP4'] as const,
+          options: ['FP16', 'FP8', 'INT8', 'INT4', 'MXFP4', 'NVFP4'] as const,
           onChange: (val: string) => {
-            if (val === 'FP16' || val === 'FP8' || val === 'INT8' || val === 'INT4' || val === 'MXFP4') {
+            if (val === 'FP16' || val === 'FP8' || val === 'INT8' || val === 'INT4' || val === 'MXFP4' || val === 'NVFP4') {
               setTestWeightPrecision(val);
             }
           }
@@ -816,9 +818,9 @@ export default function QuickEstimate() {
           value: testKVCachePrecision,
           type: 'select' as const,
           term: 'kvCachePrecision',
-          options: ['FP16', 'FP8'] as const,
+          options: ['FP16', 'FP8', 'NVFP4'] as const,
           onChange: (val: string) => {
-            if (val === 'FP16' || val === 'FP8') {
+            if (val === 'FP16' || val === 'FP8' || val === 'NVFP4') {
               setTestKVCachePrecision(val);
             }
           }

--- a/app/performance/quickEstimateHelpers.tsx
+++ b/app/performance/quickEstimateHelpers.tsx
@@ -97,11 +97,11 @@ export const GLOSSARY: Record<string, { title: string; body: string }> = {
   },
   weightPrecision: {
     title: 'Weight precision',
-    body: 'Number format for model parameters. FP16/BF16 = 2 bytes/param (full precision). FP8 = 1 byte (8-bit float). INT8 = 1 byte (8-bit integer). INT4 = 0.5 bytes (4-bit integer). MXFP4 = 0.5 bytes (Microscaling FP4). Lower precision reduces memory but may impact quality.',
+    body: 'Number format for model parameters. FP16/BF16 = 2 bytes/param (full precision). FP8 = 1 byte (8-bit float). INT8 = 1 byte (8-bit integer). INT4 = 0.5 bytes (4-bit integer). MXFP4 = 0.56 bytes (Microscaling FP4, Hopper+). NVFP4 = 0.58 bytes (NVIDIA FP4, Blackwell only). Lower precision reduces memory but may impact quality.',
   },
   kvCachePrecision: {
     title: 'KV cache precision',
-    body: 'Number format for key-value cache vectors. FP16 = 2 bytes per element (standard). FP8 = 1 byte per element (half the memory, slight quality loss). Lower precision lets you fit more requests in the same memory.',
+    body: 'Number format for key-value cache vectors. FP16 = 2 bytes per element (standard). FP8 = 1 byte per element (half the memory, slight quality loss). NVFP4 = 0.58 bytes (NVIDIA FP4, Blackwell only). Lower precision lets you fit more requests in the same memory.',
   },
   moeQuantization: {
     title: 'MoE quantization mode',

--- a/lib/gpu-math/inference-config/types.ts
+++ b/lib/gpu-math/inference-config/types.ts
@@ -5,7 +5,7 @@ import type { HFModelConfig } from '@/lib/huggingface/fetch-config'
 
 export interface InferenceRequest {
   model_name: string
-  precision: 'FP16' | 'FP8' | 'INT8' | 'INT4' | 'MXFP4'  // Weight precision
+  precision: 'FP16' | 'FP8' | 'INT8' | 'INT4' | 'MXFP4' | 'NVFP4'  // Weight precision
   gpu_type: string
   gpu_count?: number  // Optional - engine recommends if not provided
   concurrent_users: number
@@ -15,7 +15,7 @@ export interface InferenceRequest {
   sla_priority: 'ttft' | 'tpot' | 'throughput'
 
   // Optional overrides
-  kv_cache_precision?: 'FP16' | 'FP8'  // KV cache dtype (defaults to match weight precision if not specified)
+  kv_cache_precision?: 'FP16' | 'FP8' | 'NVFP4'  // KV cache dtype (defaults to match weight precision if not specified)
   network_topology?: 'nvlink' | 'infiniband' | 'ethernet'
   enable_llmd?: boolean
 


### PR DESCRIPTION
## Summary

Add NVIDIA FP4 (NVFP4) as a precision option for both weight and KV cache quantization.

## What changed

- ✅ Added NVFP4 to weight precision dropdown
- ✅ Added NVFP4 to KV cache precision dropdown  
- ✅ Map NVFP4 → `gemm_quant_mode: 'nvfp4'` and `kvcache_quant_mode: 'nvfp4'`
- ✅ Updated CLI command generation for NVFP4
- ✅ Updated glossary tooltips
- ✅ Updated TypeScript types

## Technical details

**NVFP4** = NVIDIA FP4, 0.58 bytes/param
- Blackwell-specific format (B200, B300, GB200, GB300)
- Supported by AIConfigurator via `gemm_quant_mode`, `kvcache_quant_mode`, `moe_quant_mode`
- Software fallback available for older GPUs (no compatibility warnings needed)

**vs. MXFP4** = Microscaling FP4, 0.56 bytes/param (Hopper+)

Based on AIConfigurator's `NVFP4_SYSTEMS` and the tuple `("nvfp4", "nvfp4", "nvfp4")` showing it's supported across all three quantization modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added NVFP4 as a selectable weight and KV-cache precision option.
  * Performance estimates now support NVFP4 quantization modes.
  * Updated precision guidance to include MXFP4 and NVFP4 size and hardware availability details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->