### PR TITLE
fix(aicostings): parse AWS region index served as octet-stream

### DIFF
--- a/services/aicostings/tools/api_service/scrapers/cloud_rates.py
+++ b/services/aicostings/tools/api_service/scrapers/cloud_rates.py
@@ -131,7 +131,10 @@ async def _aws_region_file_urls(session: aiohttp.ClientSession) -> dict[str, str
     async with session.get(AWS_REGION_INDEX, timeout=aiohttp.ClientTimeout(total=60)) as resp:
         if resp.status != 200:
             raise RuntimeError(f"AWS region index returned {resp.status}")
-        index = await resp.json()
+        # AWS serves the Price List JSON as application/octet-stream, which
+        # aiohttp's .json() rejects by default ("unexpected mimetype"); the
+        # body is valid JSON, so skip the content-type guard.
+        index = await resp.json(content_type=None)
     regions = index.get("regions", {})
     return {code: AWS_PRICING_HOST + meta["currentVersionUrl"] for code, meta in regions.items()}
 


### PR DESCRIPTION
## Problem

AWS serves the Price List `region_index.json` with `Content-Type: application/octet-stream`. aiohttp's `resp.json()` rejects any non-`application/json` mimetype with `ContentTypeError: ...unexpected mimetype: application/octet-stream`, which fails the **entire** AWS cloud-rate scrape at `_aws_region_file_urls`.

## Fix

The body is valid JSON, so parse it with `resp.json(content_type=None)` to skip aiohttp's content-type guard. The per-region offer files are unaffected — they already stream through `ijson.parse_async(resp.content)`, which never went through the mimetype check.

## Notes

- One-line fix; no test change (the failure was in live HTTP content-type handling, which the existing mocked tests don't exercise).
- Part of a set of three independent backend fixes split into separate PRs (this one; OTel exporter opt-in #74; model-source provenance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AWS regional pricing retrieval when responses use an unexpected content type.
  * Cloud rate data can now be processed more reliably across varying API response formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->