### PR TITLE
feat(aicostings): model pricing sources as peers with provenance + ?source=

### DIFF
--- a/services/aicostings/README.md
+++ b/services/aicostings/README.md
@@ -12,7 +12,7 @@ results in Valkey, and serves them via a REST API.
 
 | Endpoint | Description |
 |---|---|
-| `GET /models` | Frontier LLM API pricing ($/M tokens, by provider and tier) |
+| `GET /models` | Frontier LLM API pricing ($/M tokens, by provider and tier); `?source=merged\|openrouter\|litellm` selects a feed |
 | `GET /systems` | GPU pricing (cloud $/hr by provider.region, hardware new/used range) |
 | `GET /health` | Service status (last scrape timestamps, staleness flags) |
 | `GET /metrics` | Prometheus / OTLP-JSON metrics (requires the `otel` extra) |
@@ -60,12 +60,23 @@ podman compose up --build
 
 ### Frontier model pricing
 
-- **OpenRouter** (`GET https://openrouter.ai/api/v1/models`) — primary
-  source; structured pricing for 100+ models.
+Two peer pricing feeds plus a curated override layer. Every model in the
+response carries a `source` field so callers can trace where a price came from,
+and `GET /models?source=` serves a single feed or the merged view:
+
+- **OpenRouter** (`GET https://openrouter.ai/api/v1/models`) — `source="openrouter"`;
+  structured pricing for 100+ models.
 - **LiteLLM Catalog** (`GET https://api.litellm.ai/model_catalog`) —
-  secondary source; fills gaps for models missing from OpenRouter.
-- **Curated YAML overrides** (`data/model-overrides.yaml`) — for models
-  missing from both, and to override either.
+  `source="litellm"`; comparable coverage from an independent feed.
+- **Curated YAML overrides** (`data/model-overrides.yaml`, optional) —
+  `source="override"`; adds models missing from both feeds and corrects
+  individual fields.
+
+The default `merged` view is a union keyed by model id. On a duplicate id the
+precedence is **overrides > OpenRouter > LiteLLM**. Overrides are applied as
+*field-level patches* — an override overlays only the fields it specifies onto
+the matching scraped record, so unspecified fields keep tracking the live feeds;
+an override for an id neither feed has is a full add.
 
 ### Cloud GPU pricing
 

--- a/services/aicostings/tests/unit/test_api.py
+++ b/services/aicostings/tests/unit/test_api.py
@@ -74,6 +74,42 @@ class TestGetModels:
         assert data["models"] == []
         assert data["stale"] is True
 
+    @pytest.mark.asyncio
+    async def test_default_source_is_merged(self, seed_data):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.get("/models")
+        assert resp.json()["source"] == "merged"
+
+    @pytest.mark.asyncio
+    async def test_source_selects_feed(self):
+        store.set_models([
+            {"id": "anthropic/claude-x", "name": "Claude X", "provider": "Anthropic",
+             "tier": "balanced", "price_per_m_input": 3.0, "price_per_m_output": 15.0,
+             "context_window": 200000, "source": "openrouter"},
+        ], source="openrouter")
+        store.set_models([
+            {"id": "meta-llama/llama-9", "name": "llama-9", "provider": "Meta",
+             "tier": "balanced", "price_per_m_input": 0.2, "price_per_m_output": 0.3,
+             "context_window": 128000, "source": "litellm"},
+        ], source="litellm")
+        store._mark_scrape("models.openrouter")
+        store._mark_scrape("models.litellm")
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            or_resp = await client.get("/models?source=openrouter")
+            lt_resp = await client.get("/models?source=litellm")
+
+        assert or_resp.json()["source"] == "openrouter"
+        assert [m["id"] for m in or_resp.json()["models"]] == ["anthropic/claude-x"]
+        assert or_resp.json()["models"][0]["source"] == "openrouter"
+        assert [m["id"] for m in lt_resp.json()["models"]] == ["meta-llama/llama-9"]
+
+    @pytest.mark.asyncio
+    async def test_invalid_source_returns_400(self):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.get("/models?source=bogus")
+        assert resp.status_code == 400
+
 
 class TestGetSystems:
     @pytest.mark.asyncio

--- a/services/aicostings/tests/unit/test_scrapers.py
+++ b/services/aicostings/tests/unit/test_scrapers.py
@@ -163,7 +163,8 @@ class TestScrapeAllModels:
     async def test_merges_overrides(self):
         openrouter_models = [
             {"id": "a/model-1", "name": "M1", "provider": "A", "tier": "fast",
-             "price_per_m_input": 1.0, "price_per_m_output": 2.0, "context_window": 8000},
+             "price_per_m_input": 1.0, "price_per_m_output": 2.0, "context_window": 8000,
+             "source": "openrouter"},
         ]
         overrides = [
             {"id": "a/model-1", "name": "M1 Override", "provider": "A", "tier": "fast",
@@ -178,13 +179,73 @@ class TestScrapeAllModels:
             patch("tools.api_service.scrapers.models.load_curated_overrides", return_value=overrides),
         ):
             mock_session = AsyncMock()
-            result, _errors = await scrape_all_models(mock_session)
+            catalogs, _errors = await scrape_all_models(mock_session)
 
+        result = catalogs["merged"]
         ids = [m["id"] for m in result]
         assert "a/model-1" in ids
         assert "custom/model" in ids
         overridden = next(m for m in result if m["id"] == "a/model-1")
         assert overridden["price_per_m_input"] == 0.5
+        assert overridden["source"] == "override"
+
+    @pytest.mark.asyncio
+    async def test_override_is_field_level_patch(self):
+        # An override that specifies only a price field must overlay that field
+        # and inherit the rest (name, tier, context_window) from the scraped
+        # record — not replace the whole record.
+        openrouter_models = [
+            {"id": "a/model-1", "name": "M1", "provider": "A", "tier": "fast",
+             "price_per_m_input": 1.0, "price_per_m_output": 2.0, "context_window": 8000,
+             "source": "openrouter"},
+        ]
+        overrides = [{"id": "a/model-1", "price_per_m_input": 0.5}]
+
+        with (
+            patch("tools.api_service.scrapers.models.fetch_openrouter_models", return_value=openrouter_models),
+            patch("tools.api_service.scrapers.models.fetch_litellm_models", return_value=[]),
+            patch("tools.api_service.scrapers.models.load_curated_overrides", return_value=overrides),
+        ):
+            patched = next(m for m in (await scrape_all_models(AsyncMock()))[0]["merged"]
+                           if m["id"] == "a/model-1")
+
+        assert patched["price_per_m_input"] == 0.5   # overlaid
+        assert patched["price_per_m_output"] == 2.0  # inherited from OpenRouter
+        assert patched["name"] == "M1"               # inherited
+        assert patched["context_window"] == 8000     # inherited
+        assert patched["source"] == "override"
+
+    @pytest.mark.asyncio
+    async def test_per_source_catalogs_and_precedence(self):
+        # OpenRouter wins over LiteLLM on a duplicate id in the merged view, but
+        # each per-source catalog keeps its own (tagged) records.
+        openrouter_models = [
+            {"id": "dup/model", "name": "OR", "provider": "X", "tier": "balanced",
+             "price_per_m_input": 1.0, "price_per_m_output": 2.0, "context_window": 8000,
+             "source": "openrouter"},
+        ]
+        litellm_models = [
+            {"id": "dup/model", "name": "LT", "provider": "X", "tier": "balanced",
+             "price_per_m_input": 9.0, "price_per_m_output": 9.0, "context_window": 4000,
+             "source": "litellm"},
+            {"id": "lt/only", "name": "LT only", "provider": "X", "tier": "balanced",
+             "price_per_m_input": 0.1, "price_per_m_output": 0.2, "context_window": 2000,
+             "source": "litellm"},
+        ]
+
+        with (
+            patch("tools.api_service.scrapers.models.fetch_openrouter_models", return_value=openrouter_models),
+            patch("tools.api_service.scrapers.models.fetch_litellm_models", return_value=litellm_models),
+            patch("tools.api_service.scrapers.models.load_curated_overrides", return_value=[]),
+        ):
+            catalogs, _errors = await scrape_all_models(AsyncMock())
+
+        assert [m["id"] for m in catalogs["openrouter"]] == ["dup/model"]
+        assert {m["id"] for m in catalogs["litellm"]} == {"dup/model", "lt/only"}
+        dup = next(m for m in catalogs["merged"] if m["id"] == "dup/model")
+        assert dup["source"] == "openrouter"        # OpenRouter wins the collision
+        assert dup["price_per_m_input"] == 1.0
+        assert {m["id"] for m in catalogs["merged"]} == {"dup/model", "lt/only"}
 
 
 # ── Cloud rates tests ─────────────────────────────────────────────────────────

--- a/services/aicostings/tools/api_service/app.py
+++ b/services/aicostings/tools/api_service/app.py
@@ -101,19 +101,24 @@ async def job_scrape_models() -> None:
     logger.info("Scraping hosted model pricing (OpenRouter + LiteLLM)...")
     start = time.monotonic()
     async with aiohttp.ClientSession() as session:
-        models, source_errors = await scrape_all_models(session)
-    if models:
-        store.set_models(models)
+        catalogs, source_errors = await scrape_all_models(session)
+    # Store each source's catalog separately (openrouter/litellm/merged) so the
+    # /models endpoint can serve one feed or the merged view. Skip empties so a
+    # failed source doesn't clobber its last-good data.
+    for source, catalog in catalogs.items():
+        if catalog:
+            store.set_models(catalog, source=source)
     for source, error in source_errors.items():
         if error is None:
             store._mark_scrape(source)
         else:
             store.set_scrape_error(source, str(error))
+    merged = catalogs.get("merged", [])
     error_count = sum(1 for e in source_errors.values() if e is not None)
-    logger.info("Stored %d models (%d source errors)", len(models), error_count)
+    logger.info("Stored %d models (%d source errors)", len(merged), error_count)
     # Partial data is still useful, so "success" means we stored something.
-    record_scrape("models", "success" if models else "error",
-                  time.monotonic() - start, records=len(models))
+    record_scrape("models", "success" if merged else "error",
+                  time.monotonic() - start, records=len(merged))
 
 
 async def job_scrape_cloud_rates() -> None:
@@ -246,27 +251,53 @@ def _stale_flag(source: str, max_age_seconds: int = 25 * 3600) -> bool:
 # ── Endpoints ─────────────────────────────────────────────────────────────────
 
 
+_MODEL_SOURCES = ("merged", "openrouter", "litellm")
+
+
 @app.get("/models")
-def get_models():
+def get_models(
+    source: str = Query(
+        default="merged",
+        examples=["merged", "openrouter", "litellm"],
+        description="Pricing source: merged (default), openrouter, or litellm.",
+    ),
+):
     """List hosted LLM API pricing ($/M tokens).
 
     Includes both proprietary frontier models (Claude, GPT, Gemini) and
     open-weight models available via inference APIs (Llama, Qwen, Mistral,
-    DeepSeek). Sourced from OpenRouter (primary) and LiteLLM (gap-fill).
+    DeepSeek). OpenRouter and LiteLLM are peer feeds; every model is tagged with
+    its `source`. Use ?source= to select a single feed or the default merged
+    view (a union keyed by model id, with curated overrides applied as
+    field-level patches).
     """
-    models = store.get_models()
+    source = source.lower()
+    if source not in _MODEL_SOURCES:
+        raise HTTPException(
+            status_code=400,
+            detail=f"invalid source '{source}'; expected one of {', '.join(_MODEL_SOURCES)}",
+        )
+
+    models = store.get_models(source)
     if models is None:
-        return JSONResponse({"models": [], "stale": True, "updated_at": None}, status_code=200)
+        return JSONResponse(
+            {"models": [], "source": source, "stale": True, "updated_at": None},
+            status_code=200,
+        )
 
     scrape_times = store.get_scrape_times()
-    # stale only if both sources are stale (partial data is still useful)
-    or_stale = _stale_flag("models.openrouter")
-    lt_stale = _stale_flag("models.litellm")
-    updated_at = scrape_times.get("models.openrouter") or scrape_times.get("models.litellm")
+    if source == "merged":
+        # merged is fresh if either feed is fresh (partial data is still useful)
+        stale = _stale_flag("models.openrouter") and _stale_flag("models.litellm")
+        updated_at = scrape_times.get("models.openrouter") or scrape_times.get("models.litellm")
+    else:
+        stale = _stale_flag(f"models.{source}")
+        updated_at = scrape_times.get(f"models.{source}")
     return {
         "models": models,
+        "source": source,
         "updated_at": updated_at,
-        "stale": or_stale and lt_stale,
+        "stale": stale,
     }
 
 

--- a/services/aicostings/tools/api_service/scrapers/models.py
+++ b/services/aicostings/tools/api_service/scrapers/models.py
@@ -2,9 +2,19 @@
 
 """Hosted LLM API pricing scrapers.
 
-Primary source:  OpenRouter API  (https://openrouter.ai/api/v1/models)
-Secondary source: LiteLLM Catalog API (https://api.litellm.ai/model_catalog)
-Curated YAML overrides for any models missing from both.
+Two peer pricing sources, plus a curated override layer. Every model carries a
+`source` field so consumers can trace where a price came from and filter by it:
+  - OpenRouter API      (https://openrouter.ai/api/v1/models)  source="openrouter"
+  - LiteLLM Catalog API (https://api.litellm.ai/model_catalog) source="litellm"
+  - Curated YAML overrides                                     source="override"
+
+scrape_all_models() returns each source's catalog separately alongside a
+`merged` view. The merged view is a union keyed by model id; on a duplicate id
+the precedence is curated overrides > OpenRouter > LiteLLM. Overrides are
+applied as *field-level patches*: an override overlays only the fields it
+specifies onto the matching scraped record (so unspecified fields keep tracking
+the live feeds), and an override for an id neither feed has is a full add. The
+/models endpoint serves any single source or the merged view via ?source=.
 """
 
 from __future__ import annotations
@@ -79,6 +89,7 @@ def _parse_openrouter_model(m: dict[str, Any]) -> dict[str, Any] | None:
         "price_per_m_input": round(price_per_m_input, 4),
         "price_per_m_output": round(price_per_m_output, 4),
         "context_window": m.get("context_length"),
+        "source": "openrouter",
     }
 
 
@@ -143,6 +154,7 @@ def _parse_litellm_model(m: dict[str, Any]) -> dict[str, Any] | None:
         "price_per_m_input": round(price_per_m_input, 4),
         "price_per_m_output": round(price_per_m_output, 4),
         "context_window": m.get("max_input_tokens"),
+        "source": "litellm",
     }
 
 
@@ -177,14 +189,19 @@ async def fetch_litellm_models(session: aiohttp.ClientSession) -> list[dict[str,
     return parsed
 
 
-ModelScrapeResult = tuple[list[dict[str, Any]], dict[str, Exception | None]]
+# catalogs keyed by source ("openrouter", "litellm", "merged"); each value is a
+# model list. errors maps the scrape source name → Exception (or None).
+ModelScrapeResult = tuple[dict[str, list[dict[str, Any]]], dict[str, Exception | None]]
 
 
 async def scrape_all_models(session: aiohttp.ClientSession) -> ModelScrapeResult:
-    """Scrape model pricing from OpenRouter and LiteLLM concurrently.
+    """Scrape model pricing from OpenRouter and LiteLLM (peer sources).
 
     Returns:
-        merged: deduplicated model list (OpenRouter primary, LiteLLM fills gaps)
+        catalogs: {"openrouter": [...], "litellm": [...], "merged": [...]} —
+            each model tagged with its `source`. The merged view is a union
+            keyed by id (precedence: overrides > OpenRouter > LiteLLM), with
+            curated overrides applied as field-level patches.
         errors: mapping of source name → Exception (or None if successful)
     """
     import asyncio
@@ -209,19 +226,30 @@ async def scrape_all_models(session: aiohttp.ClientSession) -> ModelScrapeResult
             errors[source] = e
 
     overrides = load_curated_overrides()
-    override_ids = {m["id"] for m in overrides}
 
-    # OpenRouter is primary; LiteLLM fills gaps; overrides win over both
-    or_ids = {m["id"] for m in or_models}
-    lt_gap_models = [m for m in lt_models if m["id"] not in or_ids and m["id"] not in override_ids]
+    # Merged view: union keyed by id. LiteLLM first, then OpenRouter overwrites
+    # on collision (OpenRouter wins over LiteLLM), then curated overrides win
+    # over both — applied as field-level patches so an override overlays only the
+    # fields it specifies and unspecified fields keep tracking the live feeds. An
+    # override whose id neither feed has is a full add.
+    merged_by_id: dict[str, dict[str, Any]] = {}
+    for m in lt_models:
+        merged_by_id[m["id"]] = m
+    for m in or_models:
+        merged_by_id[m["id"]] = m
+    for o in overrides:
+        oid = o.get("id")
+        if not oid:
+            continue
+        base = merged_by_id.get(oid)
+        patched = {**base, **o} if base else dict(o)
+        patched["source"] = "override"
+        merged_by_id[oid] = patched
 
-    merged = [m for m in or_models if m["id"] not in override_ids]
-    merged.extend(lt_gap_models)
-    merged.extend(overrides)
-    merged.sort(key=lambda m: m["id"])
+    merged = sorted(merged_by_id.values(), key=lambda m: m["id"])
 
     logger.info(
-        "Models merged: %d total (OpenRouter: %d, LiteLLM gaps: %d, overrides: %d)",
-        len(merged), len(or_models), len(lt_gap_models), len(overrides),
+        "Models merged: %d total (OpenRouter: %d, LiteLLM: %d, overrides: %d)",
+        len(merged), len(or_models), len(lt_models), len(overrides),
     )
-    return merged, errors
+    return {"openrouter": or_models, "litellm": lt_models, "merged": merged}, errors

--- a/services/aicostings/tools/api_service/valkey.py
+++ b/services/aicostings/tools/api_service/valkey.py
@@ -23,9 +23,12 @@ TTL_HARDWARE = 7 * 24 * 3600    # 7 days
 TTL_GPU_ID_MAPPING = 30 * 24 * 3600  # 30 days
 
 # Keys
-KEY_MODELS = "models"
 KEY_HEALTH = "health"
 KEY_GPU_ID_MAPPING = "gpu-id-mapping"
+
+
+def _key_models(source: str) -> str:
+    return f"models:{source}"
 
 
 def _key_cloud(system_id: str) -> str:
@@ -68,11 +71,11 @@ class ValkeyStore:
 
     # ── Models ────────────────────────────────────────────────────────────
 
-    def set_models(self, models: list[dict[str, Any]]) -> None:
-        self.client.setex(KEY_MODELS, TTL_MODELS, json.dumps(models))
+    def set_models(self, models: list[dict[str, Any]], source: str = "merged") -> None:
+        self.client.setex(_key_models(source), TTL_MODELS, json.dumps(models))
 
-    def get_models(self) -> list[dict[str, Any]] | None:
-        raw = self.client.get(KEY_MODELS)
+    def get_models(self, source: str = "merged") -> list[dict[str, Any]] | None:
+        raw = self.client.get(_key_models(source))
         return json.loads(raw) if raw else None
 
     # ── Cloud rates ───────────────────────────────────────────────────────


### PR DESCRIPTION
## Motivation

`/models` blended OpenRouter and LiteLLM into one anonymous list and framed one as "primary" and the other as "gap-fill" in docstrings. A consumer couldn't tell where a given price came from, nor request a specific feed. This treats a data-provenance question as a comment-wording question.

## Changes

- **Provenance**: every model carries a `source` field — `"openrouter"`, `"litellm"`, or `"override"`.
- **Source filter**: `GET /models?source=merged|openrouter|litellm` (validated; 400 otherwise), backed by **per-source Valkey keys** (`models:merged` / `models:openrouter` / `models:litellm`) so selecting a feed returns *that feed's* actual prices — not a tag-filtered subset of the merged view (which would hide LiteLLM's price for any model OpenRouter also covers).
- **Explicit precedence** for the merged view: `overrides > OpenRouter > LiteLLM`.
- **Field-level overrides**: a curated override now overlays only the fields it specifies onto the matching scraped record (unspecified fields keep tracking the live feeds); an override for an id neither feed has is a full add. Previously it replaced the whole record, freezing every field for that model — a silent-staleness footgun.
- README + module/endpoint docstrings updated.

## Tests

New coverage: field-level patch semantics, per-source precedence (OpenRouter wins a duplicate id in merged), provenance tags, and the `?source=` filter (including the 400 on an invalid source). Scraper suite passes locally (27 tests); the app/valkey tests run in CI (they need Valkey + the amd64 SDK, unavailable on arm macOS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Choose model pricing from OpenRouter, LiteLLM, or a merged catalog using the `/models` endpoint.
  * View each model’s pricing source and catalog freshness information.
  * Merged results combine both feeds, prioritize OpenRouter duplicates, and apply curated field-level updates.

* **Bug Fixes**
  * Invalid pricing-source requests now return a clear HTTP 400 response.
  * Unavailable pricing feeds are reported with the selected source and an empty result.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->