### PR TITLE
fix(aicostings): parse AWS OnDemand prices with composite dotted keys

### DIFF
--- a/services/aicostings/tests/fixtures/aws_ec2_offer_sample.json
+++ b/services/aicostings/tests/fixtures/aws_ec2_offer_sample.json
@@ -1,0 +1,92 @@
+{
+  "formatVersion": "v1.0",
+  "disclaimer": "This pricing list is for informational purposes only.",
+  "offerCode": "AmazonEC2",
+  "products": {
+    "SKUP4DSHARED": {
+      "sku": "SKUP4DSHARED",
+      "productFamily": "Compute Instance",
+      "attributes": {
+        "instanceType": "p4d.24xlarge",
+        "tenancy": "Shared",
+        "operatingSystem": "Linux",
+        "capacitystatus": "Used",
+        "preInstalledSw": "NA",
+        "licenseModel": "No License required"
+      }
+    },
+    "SKUP4DWINDOWS": {
+      "sku": "SKUP4DWINDOWS",
+      "productFamily": "Compute Instance",
+      "attributes": {
+        "instanceType": "p4d.24xlarge",
+        "tenancy": "Shared",
+        "operatingSystem": "Windows",
+        "capacitystatus": "Used",
+        "preInstalledSw": "NA",
+        "licenseModel": "No License required"
+      }
+    },
+    "SKUP4DDEDICATED": {
+      "sku": "SKUP4DDEDICATED",
+      "productFamily": "Compute Instance",
+      "attributes": {
+        "instanceType": "p4d.24xlarge",
+        "tenancy": "Dedicated",
+        "operatingSystem": "Linux",
+        "capacitystatus": "Used",
+        "preInstalledSw": "NA",
+        "licenseModel": "No License required"
+      }
+    }
+  },
+  "terms": {
+    "OnDemand": {
+      "SKUP4DSHARED": {
+        "SKUP4DSHARED.JRTCKXETXF": {
+          "offerTermCode": "JRTCKXETXF",
+          "sku": "SKUP4DSHARED",
+          "priceDimensions": {
+            "SKUP4DSHARED.JRTCKXETXF.6YS6EN2CT7": {
+              "rateCode": "SKUP4DSHARED.JRTCKXETXF.6YS6EN2CT7",
+              "unit": "Hrs",
+              "pricePerUnit": {
+                "USD": "32.7726000000"
+              }
+            }
+          }
+        }
+      },
+      "SKUP4DWINDOWS": {
+        "SKUP4DWINDOWS.JRTCKXETXF": {
+          "offerTermCode": "JRTCKXETXF",
+          "sku": "SKUP4DWINDOWS",
+          "priceDimensions": {
+            "SKUP4DWINDOWS.JRTCKXETXF.6YS6EN2CT7": {
+              "rateCode": "SKUP4DWINDOWS.JRTCKXETXF.6YS6EN2CT7",
+              "unit": "Hrs",
+              "pricePerUnit": {
+                "USD": "40.0000000000"
+              }
+            }
+          }
+        }
+      },
+      "SKUP4DDEDICATED": {
+        "SKUP4DDEDICATED.JRTCKXETXF": {
+          "offerTermCode": "JRTCKXETXF",
+          "sku": "SKUP4DDEDICATED",
+          "priceDimensions": {
+            "SKUP4DDEDICATED.JRTCKXETXF.6YS6EN2CT7": {
+              "rateCode": "SKUP4DDEDICATED.JRTCKXETXF.6YS6EN2CT7",
+              "unit": "Hrs",
+              "pricePerUnit": {
+                "USD": "39.4400000000"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/services/aicostings/tests/unit/test_scrapers.py
+++ b/services/aicostings/tests/unit/test_scrapers.py
@@ -11,9 +11,11 @@ import pytest
 
 from tools.api_service.scrapers.cloud_rates import (
     _aws_gpu_instance_types,
+    _aws_scrape_region,
     _merge_records,
     active_scrapers,
     load_gpu_id_mapping,
+    scrape_aws,
     scrape_azure,
     scrape_vastai,
 )
@@ -318,6 +320,84 @@ class TestAwsInstanceTypes:
             "A100 80GB": "a100_sxm",
         }
         assert _aws_gpu_instance_types(mapping) == {"p5.48xlarge", "p4d.24xlarge"}
+
+
+class _AsyncByteReader:
+    """Minimal async file-like over bytes for ijson.parse_async (mimics aiohttp
+    StreamReader.read(n))."""
+
+    def __init__(self, data: bytes):
+        self._data = data
+        self._pos = 0
+
+    async def read(self, n: int = -1) -> bytes:
+        if n is None or n < 0:
+            chunk = self._data[self._pos:]
+            self._pos = len(self._data)
+        else:
+            chunk = self._data[self._pos:self._pos + n]
+            self._pos += len(chunk)
+        return chunk
+
+
+class TestAwsScrapeRegion:
+    """Regression tests for the AWS Price List OnDemand parser.
+
+    The fixture reproduces AWS's real *composite dotted* term/rate keys
+    (`<sku>.<offerTermCode>` and `<sku>.<offerTermCode>.<rateCode>`), which
+    previously defeated the fixed-length prefix check and silently yielded zero
+    records — the reason AWS never appeared in the Sources cloud-provider list.
+    """
+
+    def _fixture_bytes(self) -> bytes:
+        return (FIXTURES_DIR / "aws_ec2_offer_sample.json").read_bytes()
+
+    def _session_for(self, data: bytes) -> MagicMock:
+        mock_response = MagicMock()
+        mock_response.status = 200
+        mock_response.content = _AsyncByteReader(data)
+
+        @asynccontextmanager
+        async def mock_get(*args, **kwargs):
+            yield mock_response
+
+        session = MagicMock()
+        session.get = mock_get
+        return session
+
+    @pytest.mark.asyncio
+    async def test_extracts_ondemand_price_from_composite_keys(self):
+        session = self._session_for(self._fixture_bytes())
+        records = await _aws_scrape_region(
+            session, "us-east-1", "http://x", {"p4d.24xlarge"}, {"p4d.24xlarge": "a100_sxm"},
+        )
+        # Only the Shared+Linux+Used+NA SKU is priced; Windows and Dedicated are
+        # filtered out at the product stage, so exactly one on-demand record.
+        assert records == [{
+            "system_id": "a100_sxm",
+            "provider_region": "aws.us-east-1",
+            "on_demand": 32.7726,
+            "spot_median": None,
+        }]
+
+    @pytest.mark.asyncio
+    async def test_scrape_aws_raises_when_no_records(self, monkeypatch):
+        # A product file with no matching SKUs must raise (not return []), so a
+        # silently-empty scrape surfaces in /health instead of a fresh success.
+        empty = json.dumps({"products": {}, "terms": {"OnDemand": {}}}).encode()
+        session = self._session_for(empty)
+
+        async def fake_urls(_session):
+            return {"us-east-1": "http://x"}
+
+        monkeypatch.setattr(
+            "tools.api_service.scrapers.cloud_rates._aws_region_file_urls", fake_urls,
+        )
+        monkeypatch.setattr(
+            "tools.api_service.scrapers.cloud_rates.AWS_PRICING_REGIONS", ["us-east-1"],
+        )
+        with pytest.raises(RuntimeError, match="no rate records"):
+            await scrape_aws(session, {"p4d.24xlarge": "a100_sxm"})
 
 
 _KEY_VARS = ["RUNPOD_API_KEY", "LAMBDA_API_KEY", "GCP_BILLING_API_KEY",

--- a/services/aicostings/tools/api_service/scrapers/cloud_rates.py
+++ b/services/aicostings/tools/api_service/scrapers/cloud_rates.py
@@ -149,6 +149,13 @@ async def _aws_scrape_region(
     attributes at a time (they arrive contiguously), keep the SKUs that match a
     GPU instance type + standard Linux/Shared/Used/NA terms, then pick up their
     on-demand USD/hr in the same single pass.
+
+    NOTE: the OnDemand term/rate keys are *composite and contain dots* — e.g.
+    `terms.OnDemand.<sku>.<sku>.<offerTermCode>.priceDimensions.<sku>.<offerTermCode>.<rateCode>.pricePerUnit.USD`
+    — so the USD leaf's dotted prefix has a variable component count and cannot
+    be matched by a fixed `len(parts)`/positional check. The SKU token itself
+    never contains a dot, so we take it as the third path component and match the
+    USD leaf by suffix instead.
     """
     matched_skus: dict[str, str] = {}  # sku -> instance_type
     seen: set[str] = set()             # (system_id, region) already recorded
@@ -184,20 +191,19 @@ async def _aws_scrape_region(
                 if cur_sku is not None:
                     finalize(cur_sku, cur_attrs)
                     cur_sku, cur_attrs = None, {}
-                parts = prefix.split(".")
-                # terms.OnDemand.<sku>.<term>.priceDimensions.<pd>.pricePerUnit.USD
-                if (
-                    len(parts) == 8 and event == "string"
-                    and parts[4] == "priceDimensions" and parts[6] == "pricePerUnit" and parts[7] == "USD"
-                    and parts[2] in matched_skus
-                ):
+                # Match the USD leaf by suffix; the SKU is always the 3rd path
+                # component (it has no dots) even though later term/rate keys do.
+                if event == "string" and prefix.endswith(".pricePerUnit.USD"):
+                    sku = prefix.split(".", 3)[2]  # terms . OnDemand . <sku> . …
+                    if sku not in matched_skus:
+                        continue
                     try:
                         usd = float(value)
                     except (TypeError, ValueError):
                         continue
                     if usd <= 0:
                         continue
-                    system_id = _map_gpu_name(matched_skus[parts[2]], mapping)
+                    system_id = _map_gpu_name(matched_skus[sku], mapping)
                     if not system_id or (system_id, region) in seen:
                         continue
                     seen.add((system_id, region))
@@ -225,6 +231,17 @@ async def scrape_aws(session: aiohttp.ClientSession, mapping: dict[str, str]) ->
         region_records = await _aws_scrape_region(session, region, url, want_types, mapping)
         records.extend(region_records)
         logger.info("AWS %s: %d GPU rate records", region, len(region_records))
+    # We map real, widely-available instance types (p4d/p5), so a completely
+    # empty result means the parse silently matched nothing — almost certainly a
+    # Price List schema change. Propagate it as an error (matching Azure's
+    # raise-on-total-failure contract) so /health surfaces it instead of
+    # recording a misleading "fresh" success with no data.
+    if not records:
+        raise RuntimeError(
+            f"AWS scrape produced no rate records for {len(want_types)} GPU instance "
+            f"type(s) across region(s) {AWS_PRICING_REGIONS}; the Price List schema may "
+            "have changed"
+        )
     logger.info("AWS: %d rate records across %d region(s)", len(records), len(AWS_PRICING_REGIONS))
     return records
 


### PR DESCRIPTION
## Problem

AWS never appeared in the Sources **Cloud provider preference** picker, even though the `cloud.aws` source reported fresh in `/health`. Root cause: `scrape_aws` matched the correct product SKUs but extracted **zero** OnDemand prices, so no `aws.*` rates reached `/systems`.

The AWS Price List OnDemand term/rate keys are *composite and contain dots*:

```
terms.OnDemand.<sku>.<sku>.<offerTermCode>.priceDimensions.<sku>.<offerTermCode>.<rateCode>.pricePerUnit.USD
```

The ijson prefix therefore splits into a variable number of components, so the previous `len(parts) == 8` positional check was unsatisfiable. Verified empirically against the live us-east-1 offer file: 4 SKUs passed the product filter, 0 records were produced.

A secondary bug hid this: a silently-empty AWS scrape returned `[]` without raising, so `/health` recorded it as a fresh success rather than an error.

## Fix

1. **Price extraction** — match the USD leaf by suffix (`.pricePerUnit.USD`) and take the SKU as the dot-free 3rd path component, instead of a fixed component count.
2. **Health honesty** — `scrape_aws` now raises when it produces zero records (we map real, widely-available p4d/p5 types), so the failure surfaces in `/health` (mirrors Azure's raise-on-total-failure contract).

## Tests

Adds `aws_ec2_offer_sample.json` reproducing AWS's real composite-key structure, plus regression tests for both the price extraction and the empty-result guard. Full scraper suite passes (29) and `ruff check` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AWS EC2 pricing extraction for composite price-list entries.
  * AWS GPU pricing scans now correctly identify eligible Linux shared-use rates while excluding unsupported product types.
  * Clear errors are now reported when no matching GPU pricing records are found.

* **Tests**
  * Added regression coverage for AWS pricing parsing and missing-rate scenarios.
  * Added representative AWS EC2 pricing data for shared Linux, shared Windows, and dedicated Linux instances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->