### PR TITLE
fix(aiconfigurator): stop /docs placeholder model_config causing 500

### DIFF
--- a/services/aiconfigurator/tests/unit/tools/test_api_service.py
+++ b/services/aiconfigurator/tests/unit/tools/test_api_service.py
@@ -905,6 +905,28 @@ class TestModelConfigPassthrough:
         resp = client.post("/memory", json=body)
         assert resp.status_code == 200
 
+    @patch("tools.api_service.app.cli_recommend")
+    def test_empty_model_config_falls_back_to_hf_resolution(self, mock_recommend):
+        # An empty dict must not be written as a config.json; the SDK should
+        # receive the original model path and resolve it from HuggingFace.
+        mock_recommend.return_value = make_mock_cli_result()
+        body = {**VALID_RECOMMEND_BODY, "model_config": {}}
+        resp = client.post("/recommend", json=body)
+        assert resp.status_code == 200
+        assert mock_recommend.call_args.kwargs["model_path"] == "Qwen/Qwen3-32B"
+
+    @patch("tools.api_service.app.cli_recommend")
+    def test_invalid_model_config_returns_422(self, mock_recommend):
+        # A non-empty but incomplete config (e.g. Swagger's placeholder) makes
+        # the SDK raise KeyError('architectures'); surface a clear 422, not 500.
+        mock_recommend.side_effect = KeyError("architectures")
+        body = {**VALID_RECOMMEND_BODY, "model_config": {"additionalProp1": {}}}
+        resp = client.post("/recommend", json=body)
+        assert resp.status_code == 422
+        detail = resp.json()["detail"]
+        assert "model_config" in detail
+        assert "architectures" in detail
+
 
 class TestOpenTelemetry:
     """Tests for OpenTelemetry instrumentation integration."""

--- a/services/aiconfigurator/tests/unit/tools/test_api_service.py
+++ b/services/aiconfigurator/tests/unit/tools/test_api_service.py
@@ -9,7 +9,9 @@ requiring the Rust native extension or performance databases.
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass, field
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import numpy as np
@@ -917,11 +919,21 @@ class TestModelConfigPassthrough:
 
     @patch("tools.api_service.app.cli_recommend")
     def test_invalid_model_config_returns_422(self, mock_recommend):
-        # A non-empty but incomplete config (e.g. Swagger's placeholder) makes
-        # the SDK raise KeyError('architectures'); surface a clear 422, not 500.
-        mock_recommend.side_effect = KeyError("architectures")
+        # A non-empty but incomplete config (e.g. Swagger's placeholder) is
+        # written to a temp config.json and forwarded to the SDK, which raises
+        # KeyError('architectures'). Verify both that the payload reached the SDK
+        # via a config file and that the KeyError surfaces as a clear 422.
+        forwarded = {}
+
+        def _check_then_raise(*args, **kwargs):
+            config_path = Path(kwargs["model_path"]) / "config.json"
+            forwarded["config"] = json.loads(config_path.read_text())
+            raise KeyError("architectures")
+
+        mock_recommend.side_effect = _check_then_raise
         body = {**VALID_RECOMMEND_BODY, "model_config": {"additionalProp1": {}}}
         resp = client.post("/recommend", json=body)
+        assert forwarded["config"] == {"additionalProp1": {}}
         assert resp.status_code == 422
         detail = resp.json()["detail"]
         assert "model_config" in detail

--- a/services/aiconfigurator/tools/api_service/app.py
+++ b/services/aiconfigurator/tools/api_service/app.py
@@ -70,7 +70,9 @@ class RecommendRequest(BaseModel):
     model_config_data: dict | None = Field(
         default=None,
         alias="model_config",
-        description="Pre-fetched HuggingFace model config.json. Skips HF download.",
+        examples=[None],
+        description="Pre-fetched HuggingFace model config.json. Skips HF download. "
+        "Leave null to let the service resolve the model from HuggingFace.",
     )
 
     model_config = {"populate_by_name": True}
@@ -109,7 +111,9 @@ class EstimateRequest(BaseModel):
     model_config_data: dict | None = Field(
         default=None,
         alias="model_config",
-        description="Pre-fetched HuggingFace model config.json. Skips HF download.",
+        examples=[None],
+        description="Pre-fetched HuggingFace model config.json. Skips HF download. "
+        "Leave null to let the service resolve the model from HuggingFace.",
     )
 
     model_config = {"populate_by_name": True}
@@ -241,7 +245,9 @@ class MemoryRequest(BaseModel):
     model_config_data: dict | None = Field(
         default=None,
         alias="model_config",
-        description="Pre-fetched HuggingFace model config.json. Skips HF download.",
+        examples=[None],
+        description="Pre-fetched HuggingFace model config.json. Skips HF download. "
+        "Leave null to let the service resolve the model from HuggingFace.",
     )
 
     model_config = {"populate_by_name": True}
@@ -325,7 +331,12 @@ class _tempdir_context:
 
 
 def _with_model_config(model_path: str, config_dict: dict | None):
-    if config_dict is None:
+    # An empty dict carries no usable config — treat anything falsy as
+    # "not supplied" so the SDK resolves the model itself instead of loading a
+    # bogus config.json. (A non-empty but invalid config, such as Swagger UI's
+    # {"additionalProp1": {}} placeholder, still reaches the SDK and surfaces as
+    # a clear 422 via the KeyError branch in _common_error_handler.)
+    if not config_dict:
         return _noop_context(model_path)
     return _tempdir_context(model_path, config_dict)
 
@@ -479,6 +490,14 @@ def _common_error_handler(e: Exception, op: str, model_path: str, backend: str, 
     msg = str(e)
     if isinstance(e, NoFeasibleConfigError):
         raise HTTPException(status_code=422, detail=msg)
+    if isinstance(e, KeyError):
+        # A bare KeyError here almost always means a supplied model_config is
+        # incomplete (e.g. missing 'architectures'); str(KeyError('x')) is "'x'".
+        detail = (
+            f"Invalid or incomplete model_config for model={model_path}: missing key {msg}. "
+            "Omit model_config (or send null) to resolve the model from HuggingFace."
+        )
+        raise HTTPException(status_code=422, detail=detail)
     if isinstance(e, (ValueError, AttributeError)):
         if "system_spec" in msg or "NoneType" in msg or "unsupported model" in msg.lower():
             detail = f"No performance data available for model={model_path}, backend={backend}, system={system}."


### PR DESCRIPTION
## Problem

The example `POST /recommend` request copied from the live Swagger `/docs`
returns a 500:

```
{"detail":"'architectures'"}
```

The Swagger UI auto-generates `{"additionalProp1": {}}` as the example for the
free-form `model_config` field. That value is non-null, so the wrapper treats it
as a genuine pre-fetched HuggingFace config: it writes it to a temp
`config.json` and hands the SDK a local model path. The SDK then looks up
`config["architectures"]`, the key is missing, and the resulting
`KeyError('architectures')` falls through to the generic 500 branch where
`detail = str(e)` — i.e. `"'architectures'"`.

This is not a bug in the sizing logic; it's the docs shipping a broken
placeholder for an optional field.

## Changes

- **Fix the docs example** — add `examples=[None]` to the `model_config` field on
  all three request models (`recommend`, `estimate`, `memory`), so FastAPI's
  `/docs` emits `null` instead of the junk placeholder.
- **Harden `_with_model_config`** — treat an empty/falsy config dict as "not
  supplied" so the SDK resolves the model from HuggingFace instead of loading a
  bogus `config.json`.
- **Handle `KeyError` in `_common_error_handler`** — a non-empty but incomplete
  config now returns a clear **422** ("Invalid or incomplete model_config …
  missing key 'architectures'. Omit model_config (or send null) …") instead of a
  bare 500.
- **Tests** — add coverage for empty-config fallback and invalid-config 422.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Empty model configurations are now treated as omitted, preserving standard model resolution.
  * Invalid or incomplete model configurations now return clear HTTP 422 errors identifying missing required fields.
  * Model configuration descriptions now explain how empty and null values are handled.

* **Tests**
  * Expanded coverage for empty, invalid, and incomplete model configuration scenarios.
  * Added validation that submitted configuration data is retained and processed before validation errors are reported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->