### PR TITLE
Potential fix for code scanning alert no. 2: Server-side request forgery

### DIFF
--- a/app/api/hf-config/route.ts
+++ b/app/api/hf-config/route.ts
@@ -93,7 +93,7 @@ export async function GET(req: NextRequest): Promise<NextResponse<HFConfigRespon
   )
 
   // ── Step 2: weight bytes from safetensors.index.json ──────────────────────
-  const indexUrl = `${HF_BASE}/${modelId}/resolve/main/model.safetensors.index.json`
+  const indexUrl = `${HF_BASE}/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/resolve/main/model.safetensors.index.json`
   let weightBytes: number | null = null
   let weightSource: HFConfigResponse['weightSource'] = 'estimated'
 
@@ -120,7 +120,7 @@ export async function GET(req: NextRequest): Promise<NextResponse<HFConfigRespon
   // ── Step 3: weight bytes from HF API (fallback) ───────────────────────────
   if (weightBytes === null) {
     try {
-      const apiUrl = `${HF_BASE}/api/models/${modelId}`
+      const apiUrl = `${HF_BASE}/api/models/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}`
       const apiRes = await hfFetch(apiUrl, token)
       if (apiRes.ok) {
         const meta = await apiRes.json() as Record<string, unknown>

--- a/app/api/hf-config/route.ts
+++ b/app/api/hf-config/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 
 const HF_BASE = 'https://huggingface.co'
+const MODEL_ID_RE = /^[A-Za-z0-9][A-Za-z0-9._-]*\/[A-Za-z0-9][A-Za-z0-9._-]*$/
 
 interface HFConfigResponse {
   config:       Record<string, unknown>
@@ -26,18 +27,19 @@ export async function GET(req: NextRequest): Promise<NextResponse<HFConfigRespon
   const { searchParams } = new URL(req.url)
   const modelId = searchParams.get('model')?.trim()
 
-  if (!modelId || !modelId.includes('/')) {
+  if (!modelId || !MODEL_ID_RE.test(modelId)) {
     return NextResponse.json(
-      { error: 'invalid_model_id', message: 'Model ID must be in the format "owner/model-name"' },
+      { error: 'invalid_model_id', message: 'Model ID must be in the format "owner/model-name" using only letters, numbers, ".", "_" or "-".' },
       { status: 400 }
     )
   }
 
+  const [owner, repo] = modelId.split('/')
   const token = req.headers.get('x-hf-token') ?? undefined
   const warnings: string[] = []
 
   // ── Step 1: fetch config.json ──────────────────────────────────────────────
-  const configUrl = `${HF_BASE}/${modelId}/raw/main/config.json`
+  const configUrl = `${HF_BASE}/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/raw/main/config.json`
   let configRes: Response
 
   try {


### PR DESCRIPTION
Potential fix for [https://github.com/redhat-performance/configiq/security/code-scanning/2](https://github.com/redhat-performance/configiq/security/code-scanning/2)

The best fix is to **strictly validate and normalize `modelId` against an allowlist pattern** before using it in URL construction, and to **URL-encode each path segment** when building `configUrl`.

In `app/api/hf-config/route.ts`, replace the current minimal check (`includes('/')`) with strict validation that enforces expected Hugging Face repo id shape (`owner/model` using safe characters only, exactly two segments, no traversal). Then construct `configUrl` using encoded `owner` and `model` segments (`encodeURIComponent`) to prevent path/control-character injection while preserving intended functionality.

Needed changes:
- Add a `MODEL_ID_RE` constant.
- Replace the existing model-id validation block.
- Split validated modelId into `owner` and `repo`.
- Build `configUrl` from encoded segments.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for Hugging Face model identifiers.
  * Properly handles special characters in model owners and names when retrieving model configuration and metadata.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->