### PR TITLE
feat: Removes placeholder text in KV Cache and Estimator pages

### DIFF
--- a/app/kv-cache/KvCacheCalc.tsx
+++ b/app/kv-cache/KvCacheCalc.tsx
@@ -392,11 +392,7 @@ export default function KvCacheCalc() {
       )}
 
       {/* Placeholder */}
-      {!loading && !result && !error && (
-        <div className={styles.placeholder}>
-          Select a model and GPU system, then click Calculate
-        </div>
-      )}
+      {!loading && !result && !error}
 
       {/* Results */}
       {result && !loading && (

--- a/app/performance/PerformanceEstimate.tsx
+++ b/app/performance/PerformanceEstimate.tsx
@@ -1178,11 +1178,7 @@ export default function QuickEstimate() {
       )}
 
       {/* ---------- result tiles ---------- */}
-      {!testResult && !isCalculating && !testError && (
-        <div className={styles.card} style={{ textAlign: 'center', padding: '40px 24px', color: 'var(--t2)' }}>
-          Select a model and GPU system above, then press <strong>Calculate</strong> to see results.
-        </div>
-      )}
+      {!testResult && !isCalculating && !testError}
       {isCalculating && (
         <div className={styles.card}>
           <GpuChipLoader elapsed={elapsed} />


### PR DESCRIPTION
Resolves Issue #63 , placeholder text in KV Cache Calculator and Performance Estimator has been removed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Removed empty-state placeholder content from the KV cache calculator.
  - Removed the pre-calculation prompt card from the performance estimator.
  - Existing loading, result, and error states remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->