### PR TITLE
fix: Gate cost calculations on completed costings loading

### DIFF
--- a/app/performance/PerformanceEstimate.tsx
+++ b/app/performance/PerformanceEstimate.tsx
@@ -495,12 +495,13 @@ export default function QuickEstimate() {
 
   const realMonthlyCost = testResult && gpuPricePerHour != null ?
     realGpuCount * gpuPricePerHour * HOURS_PER_MONTH :
-    0;
+    null;
+  const realMonthlyCostForDisplay = realMonthlyCost ?? 0;
 
   const gpus = useCountUp(realGpuCount);
   const weight = useCountUp(realWeightGB);
   const kv = useCountUp(realKVPerReqMB);
-  const cost = useCountUp(realMonthlyCost);
+  const cost = useCountUp(realMonthlyCostForDisplay);
 
   const handleTourComplete = () => {
     setShowTour(false);
@@ -525,7 +526,7 @@ export default function QuickEstimate() {
   };
 
   const handleSaveEstimate = (data: { name: string; tags: string; notes: string }) => {
-    if (!testResult || !catalogGpuForPricing) return;
+    if (!testResult || !catalogGpuForPricing || gpuPricePerHour == null) return;
 
     const kvPerUserGB = (testResult.memory_analysis.kv_cache_used_gb || 0) / testConcurrentUsers;
     const kvMBPerToken = (kvPerUserGB * 1000) / (testISL + testOSL);
@@ -554,8 +555,8 @@ export default function QuickEstimate() {
         kvCacheMBPerToken: kvMBPerToken,
         kvCategory: testResult.memory_analysis.kv_category || 'KV-1',
         kvCategoryLabel: testResult.memory_analysis.kv_category_label || 'Standard Dense',
-        cloudCostMonthly: realMonthlyCost,
-        cloudCost5Year: realMonthlyCost * 60,
+        cloudCostMonthly: realMonthlyCost ?? 0,
+        cloudCost5Year: (realMonthlyCost ?? 0) * 60,
         selfHostedCostMonthly: (catalogGpuForPricing.hardware_cost_usd * realGpuCount) / AMORT_MONTHS_5YR,
         selfHostedCost5Year: catalogGpuForPricing.hardware_cost_usd * realGpuCount,
       },
@@ -667,7 +668,7 @@ export default function QuickEstimate() {
       testResult.memory_analysis.weight_gb.toFixed(1),
       (testResult.memory_analysis.kv_cache_used_gb || 0).toFixed(1),
       testResult.memory_analysis.kv_category_label || 'Standard Dense',
-      `$${realMonthlyCost.toLocaleString()}`, `$${(realMonthlyCost * AMORT_MONTHS_5YR).toLocaleString()}`,
+      `$${(realMonthlyCost ?? 0).toLocaleString()}`, `$${((realMonthlyCost ?? 0) * AMORT_MONTHS_5YR).toLocaleString()}`,
       `$${((catalogGpuForPricing.hardware_cost_usd * realGpuCount) / AMORT_MONTHS_5YR).toFixed(0)}`,
       `$${(catalogGpuForPricing.hardware_cost_usd * realGpuCount).toLocaleString()}`
     ];
@@ -1333,7 +1334,7 @@ export default function QuickEstimate() {
           />
         </div>
 
-        {costingsEnabled && gpuPricePerHour == null && (
+        {costingsEnabled && gpuPricePerHour == null && !costings.isLoading && (
           <div style={{
             border: '1px solid #d2d2d2', borderRadius: '6px', padding: '14px',
             fontSize: '13px', fontFamily: 'var(--font-mono)', color: '#54585c',
@@ -1798,11 +1799,11 @@ export default function QuickEstimate() {
         <Button variant="secondary" onClick={handleCopyCLICommand} isDisabled={!testResult}>
           Copy CLI command
         </Button>
-        <Button variant="secondary" onClick={handleExportToSheets} isDisabled={!testResult || !catalogGpuForPricing}>
+        <Button variant="secondary" onClick={handleExportToSheets} isDisabled={!testResult || !catalogGpuForPricing || gpuPricePerHour == null}>
           Export to Sheets
         </Button>
         <span className={styles.footerSpacer} />
-        <Button variant="primary" onClick={() => setShowSaveModal(true)} isDisabled={!testResult || !catalogGpuForPricing}>
+        <Button variant="primary" onClick={() => setShowSaveModal(true)} isDisabled={!testResult || !catalogGpuForPricing || gpuPricePerHour == null}>
           Save estimate{savedCount > 0 && ` (${savedCount})`}
         </Button>
       </div>

--- a/app/recommend/AdvancedEstimate.tsx
+++ b/app/recommend/AdvancedEstimate.tsx
@@ -100,8 +100,9 @@ function friendlyErrorTitle(code: string | null): string {
 function friendlyErrorMessage(code: string | null, raw: string): string {
   switch (code) {
     case 'AIC_TIMEOUT':
-    case 'NETWORK_ERROR':
       return 'The AIConfigurator service took too long to respond. This can happen with complex configurations.';
+    case 'NETWORK_ERROR':
+      return 'Could not reach the AIConfigurator service or it takes too long to respond.';
     case 'AIC_NO_CONFIGURATION':
       return 'No valid GPU configuration found for this model and hardware combination.';
     case 'AIC_UNAVAILABLE':


### PR DESCRIPTION
Prevent cost data being unavailable while pricing is loading.

## Changes

- Add `!costings.isLoading` guard to unavailable cloud rate notice
- Set `realMonthlyCost` to null (not 0) when `gpuPricePerHour` unavailable
- Require `gpuPricePerHour != null` to enable Save and Export buttons
- Add same check to `handleSaveEstimate` guard clause

## Why

Gating on completed loading prevents users seeing "unavailable" message while data is still fetching. Requiring resolved pricing prevents saving/exporting estimates with missing cost data.

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Cloud cost calculations now handle unavailable pricing rates more accurately.
  - Saved and exported cost values use zero when rates are unavailable.
  - Unavailable-rate messaging is hidden while pricing data is loading.
  - Error messages now distinguish between request timeouts and unreachable or timed-out services.

- **User Experience**
  - Save and Export actions remain disabled until a cloud rate is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->