### PR TITLE
fix: Align hardware amortization period with PerformanceEstimate

### DIFF
--- a/app/recommend/AdvancedEstimate.tsx
+++ b/app/recommend/AdvancedEstimate.tsx
@@ -31,7 +31,7 @@ function modelSuggestions(): string {
 }
 import { GpuChipLoader } from '@/components/GpuChipLoader/GpuChipLoader';
 import { Term } from '@/app/performance/quickEstimateHelpers';
-import { HOURS_PER_MONTH, AMORT_MONTHS_3YR } from '@/lib/utils/format';
+import { HOURS_PER_MONTH, AMORT_MONTHS_5YR } from '@/lib/utils/format';
 
 
 // ─── FlipTile (reused from Quick Estimate pattern) ───────────────────────────
@@ -303,12 +303,12 @@ export default function AdvancedEstimate() {
   const memVal = useCountUp(result?.memory.value ?? 0, 750, 1);
 
   const hwCost = costings.gpuHardwareCosts.get(gpuSystem)?.new_usd ?? null;
-  const amortizedHwPerHour = hwCost != null ? hwCost / (AMORT_MONTHS_3YR * HOURS_PER_MONTH) : null;
+  const amortizedHwPerHour = hwCost != null ? hwCost / (AMORT_MONTHS_5YR * HOURS_PER_MONTH) : null;
   const resolvedCloudRate = resolveCloudRate(costings.gpuCloudRates.get(gpuSystem), preferredCloudProvider);
   const pricePerHour = resolvedCloudRate?.rate ?? amortizedHwPerHour ?? null;
   const rateBasis = resolvedCloudRate
     ? `${resolvedCloudRate.provider.replace('.', ' · ')} ${resolvedCloudRate.kind === 'spot' ? 'spot' : 'on-demand'}`
-    : amortizedHwPerHour != null ? 'amortized hardware'
+    : amortizedHwPerHour != null ? 'amortized hardware (5-year)'
     : '';
   const numGpus = result?.recommendation.totalGpus ?? 0;
   const monthlyCost = pricePerHour != null ? numGpus * pricePerHour * HOURS_PER_MONTH : null;


### PR DESCRIPTION
Addresses CodeRabbit review comment in PR #72.

## Changes

- Change AdvancedEstimate hardware cost amortization from 3-year to 5-year
- Update import to use AMORT_MONTHS_5YR instead of AMORT_MONTHS_3YR
- Add period clarification to rate basis label: 'amortized hardware (5-year)'

## Why

Ensures consistent cost calculations between AdvancedEstimate and PerformanceEstimate tools. Both now use the same 5-year amortization period for hardware costs.

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Hardware amortization is now calculated over five years instead of three.
  - The fallback rate label now clearly identifies five-year hardware amortization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->