### PR TITLE
fix: Change default concurrency from 32 to 1 user

### DIFF
--- a/app/performance/PerformanceEstimate.tsx
+++ b/app/performance/PerformanceEstimate.tsx
@@ -165,7 +165,7 @@ export default function QuickEstimate() {
   const [toastMessage, setToastMessage] = React.useState('');
 
   // Interactive controls
-  const [testConcurrentUsers, setTestConcurrentUsers] = React.useState(32);
+  const [testConcurrentUsers, setTestConcurrentUsers] = React.useState(1);
   const [testISL, setTestISL] = React.useState(2048);
   const [testOSL, setTestOSL] = React.useState(128);
   const [testPrefix, setTestPrefix] = React.useState(0);
@@ -179,7 +179,7 @@ export default function QuickEstimate() {
   
   const [islInput, setIslInput] = React.useState('2048');
   const [oslInput, setOslInput] = React.useState('128');
-  const [concurrentUsersInput, setConcurrentUsersInput] = React.useState('32');
+  const [concurrentUsersInput, setConcurrentUsersInput] = React.useState('1');
   const [prefixInput, setPrefixInput] = React.useState('0');
   const [tpSizeInput, setTpSizeInput] = React.useState('1');
   const [ppSizeInput, setPpSizeInput] = React.useState('1');

--- a/app/recommend/AdvancedEstimate.tsx
+++ b/app/recommend/AdvancedEstimate.tsx
@@ -170,7 +170,7 @@ export default function AdvancedEstimate() {
   const [osl, setOsl] = React.useState(128);
   const [ttft, setTtft] = React.useState(1000);
   const [tpot, setTpot] = React.useState(30);
-  const [targetConcurrency, setTargetConcurrency] = React.useState(32);
+  const [targetConcurrency, setTargetConcurrency] = React.useState(1);
   const [requestLatency, setRequestLatency] = React.useState<number | null>(null);
   const [prefix, setPrefix] = React.useState(0);
 
@@ -188,7 +188,7 @@ export default function AdvancedEstimate() {
   const [oslInput, setOslInput] = React.useState('128');
   const [ttftInput, setTtftInput] = React.useState('1000');
   const [tpotInput, setTpotInput] = React.useState('30');
-  const [concurrencyInput, setConcurrencyInput] = React.useState('32');
+  const [concurrencyInput, setConcurrencyInput] = React.useState('1');
   const [latencyInput, setLatencyInput] = React.useState('');
   const [prefixInput, setPrefixInput] = React.useState('0');
 

--- a/lib/workload-presets.ts
+++ b/lib/workload-presets.ts
@@ -16,6 +16,6 @@ export const DEFAULT_WORKLOAD: WorkloadPreset = {
   osl: 128,
   ttft: 1000,
   tpot: 30,
-  concurrency: 32,
+  concurrency: 1,
   prefix: 0,
 }


### PR DESCRIPTION
## Changes

- Set default concurrent users in Performance Estimator to 1 (was 32)
- Set default target concurrency in Advanced Estimate to 1 (was 32)

## Why

Starting with a single concurrent user provides a minimal, conservative default that results in fewer GPUs and lower estimated costs. Users can easily adjust upward based on their actual traffic patterns. This helps them understand the baseline infrastructure needed before scaling.

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Updates**
  - Default concurrent-user values in Performance Estimates are now set to 1.
  - Default target-concurrency values in Advanced Estimates are now set to 1.
  - Default workload concurrency is now set to 1.
  - Displayed input values match these defaults when starting a new estimate, providing consistent starting values across estimation tools.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->