### PR TITLE
fix: Simplify GPU dropdown labels to show only memory

### DIFF
--- a/components/ui/GpuSystemInput.tsx
+++ b/components/ui/GpuSystemInput.tsx
@@ -55,7 +55,7 @@ export function GpuSystemInput({ id, value, onChange, gpuOptions }: GpuSystemInp
 
   const selectedOption = gpuOptions.find(g => g.systemId === value)
   const selectedLabel = selectedOption
-    ? `${selectedOption.label}${selectedOption.vramGb ? ` — ${selectedOption.vramGb} GB` : ''}${selectedOption.bandwidthTbps != null ? ` · ${selectedOption.bandwidthTbps} TB/s` : ''}${selectedOption.tflopsBf16 != null ? ` · ${selectedOption.tflopsBf16.toFixed(0)} TFLOPS` : ''}`
+    ? `${selectedOption.label}${selectedOption.vramGb ? ` — ${selectedOption.vramGb} GB` : ''}`
     : 'Select GPU system…'
 
   const toggle = (tRef: React.RefObject<HTMLButtonElement>) => (
@@ -107,8 +107,6 @@ export function GpuSystemInput({ id, value, onChange, gpuOptions }: GpuSystemInp
                       <span>{g.label}</span>
                       <span className={styles.specs}>
                         {g.vramGb ? `${g.vramGb} GB` : ''}
-                        {g.bandwidthTbps != null ? ` · ${g.bandwidthTbps} TB/s` : ''}
-                        {g.tflopsBf16 != null ? ` · ${g.tflopsBf16.toFixed(0)} TFLOPS` : ''}
                       </span>
                     </div>
                   </SelectOption>


### PR DESCRIPTION
## Changes

Remove throughput (TB/s) and performance (TFLOPS) specs from GPU option labels in the dropdown, keeping only VRAM (GB).

## Why

Reduces visual clutter and focuses users on the most relevant GPU selection criterion — memory capacity. Other specs are still available in the helper text below the dropdown for reference.

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Improvements**
  * Simplified GPU selection dropdown labels to show only the GPU name and VRAM.
  * Bandwidth and BF16 TFLOPS remain available in the selected GPU details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->