### PR TITLE
feat: Hugging Face models in dropdown + selected-model status badges

### DIFF
--- a/app/kv-cache/KvCacheCalc.tsx
+++ b/app/kv-cache/KvCacheCalc.tsx
@@ -102,12 +102,14 @@ export default function KvCacheCalc() {
   React.useEffect(() => {
     setHfConfig(null);
     if (catalogLoading || !needsHfConfig(model, aicModels) || !model.includes('/')) return;
+    let cancelled = false;
     const timer = setTimeout(() => {
       fetchModelConfig(model, hfToken).then(r => {
-        if (r.success && r.config) setHfConfig(r.config as Record<string, unknown>);
+        // Ignore a response for a model the user has since moved away from.
+        if (!cancelled && r.success && r.config) setHfConfig(r.config as Record<string, unknown>);
       });
     }, 500);
-    return () => clearTimeout(timer);
+    return () => { cancelled = true; clearTimeout(timer); };
   }, [model, hfToken, aicModels, catalogLoading]);
 
   const handleTpSizeChange = (raw: string) => {

--- a/app/kv-cache/KvCacheCalc.tsx
+++ b/app/kv-cache/KvCacheCalc.tsx
@@ -10,6 +10,8 @@ import { useSettings, type InferenceBackend } from '@/contexts/SettingsContext'
 import { getAppConfig } from '@/lib/app-config'
 import { ModelInput, type ModelStatus } from '@/components/ui/ModelInput';
 import { ComboBox, type ComboBoxItem } from '@/components/ModelComboBox/ModelComboBox';
+import { buildModelItems, needsHfConfig } from '@/lib/model-options';
+import { fetchModelConfig } from '@/lib/huggingface/fetch-config';
 import { GpuSystemInput } from '@/components/ui/GpuSystemInput'
 import type { KvCacheCalcResult } from '@/lib/api/kv-cache-calc'
 import styles from './KvCacheCalc.module.css'
@@ -24,7 +26,7 @@ const BREAKDOWN_COLORS: Record<string, string> = {
 }
 
 export default function KvCacheCalc() {
-  const { hydrated, defaultModel: settingsDefaultModel, inferenceBackend, backendVersion: settingsBackendVersion } = useSettings()
+  const { hydrated, hfToken, defaultModel: settingsDefaultModel, inferenceBackend, backendVersion: settingsBackendVersion } = useSettings()
   const { modelOptions: aicModels, gpuOptions: aicGpus, isLoading: catalogLoading } = useAicCatalog()
   const MODEL_OPTIONS = aicModels
 
@@ -90,18 +92,23 @@ export default function KvCacheCalc() {
     if (!isNaN(n) && n >= 1) setMaxBatchSize(n);
   };
 
-  const modelItems: ComboBoxItem[] = React.useMemo(() =>
-    aicModels.map(m => {
-      const slash = m.indexOf('/');
-      const isTested = getAppConfig().testedModels.includes(m);
-      return {
-        value: m,
-        label: m,
-        group: slash > 0 ? m.slice(0, slash) : '',
-        isTested,
-        inCatalog: true,
-      };
-    }), [aicModels]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- hydrated gates config.json readiness
+  const modelItems: ComboBoxItem[] = React.useMemo(() => buildModelItems(aicModels), [aicModels, hydrated]);
+
+  // HF config for models AIC can't resolve from its catalog (incl. tested models
+  // outside the catalog). Fetched on model change, sent to /api/memory on calc.
+  const [hfConfig, setHfConfig] = React.useState<Record<string, unknown> | null>(null);
+
+  React.useEffect(() => {
+    setHfConfig(null);
+    if (catalogLoading || !needsHfConfig(model, aicModels) || !model.includes('/')) return;
+    const timer = setTimeout(() => {
+      fetchModelConfig(model, hfToken).then(r => {
+        if (r.success && r.config) setHfConfig(r.config as Record<string, unknown>);
+      });
+    }, 500);
+    return () => clearTimeout(timer);
+  }, [model, hfToken, aicModels, catalogLoading]);
 
   const handleTpSizeChange = (raw: string) => {
     const digits = raw.replace(/[^0-9]/g, '');
@@ -148,6 +155,7 @@ export default function KvCacheCalc() {
       memory_fraction_value: memFractionValue,
     }
     if (backendVersion.trim()) requestBody.backend_version = backendVersion.trim()
+    if (needsHfConfig(model, aicModels) && hfConfig) requestBody.model_config = hfConfig
     const moeTp = parseInt(moeTpSize, 10)
     if (!isNaN(moeTp) && moeTp > 0) requestBody.moe_tp_size = moeTp
     const moeEp = parseInt(moeEpSize, 10)

--- a/app/performance/PerformanceEstimate.tsx
+++ b/app/performance/PerformanceEstimate.tsx
@@ -30,6 +30,7 @@ import { fetchEstimateAsInferenceResult, EstimateError } from '@/lib/api/estimat
 import { InfoStrip, InfoStripAction } from '@/components/ui/InfoStrip';
 import { ModelInput, type ModelStatus } from '@/components/ui/ModelInput';
 import { ComboBox, type ComboBoxItem } from '@/components/ModelComboBox/ModelComboBox';
+import { buildModelItems, needsHfConfig } from '@/lib/model-options';
 import { GpuSystemInput } from '@/components/ui/GpuSystemInput';
 import { useAicCatalog } from '@/lib/hooks/useAicCatalog';
 import { GpuChipLoader } from '@/components/GpuChipLoader/GpuChipLoader';
@@ -82,18 +83,8 @@ export default function QuickEstimate() {
   const [model, setModel] = React.useState('');
   const [gpu, setGpu] = React.useState(() => getAppConfig().defaultSystem);
 
-  const modelItems: ComboBoxItem[] = React.useMemo(() =>
-    aicModels.map(m => {
-      const slash = m.indexOf('/');
-      const isTested = getAppConfig().testedModels.includes(m);
-      return {
-        value: m,
-        label: m,
-        group: slash > 0 ? m.slice(0, slash) : '',
-        isTested,
-        inCatalog: true,
-      };
-    }), [aicModels]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- hydrated gates config.json readiness
+  const modelItems: ComboBoxItem[] = React.useMemo(() => buildModelItems(aicModels), [aicModels, hydrated]);
 
   // Set model from settings after context has loaded from localStorage
   const modelFromSettings = React.useRef(false);
@@ -250,9 +241,12 @@ export default function QuickEstimate() {
   React.useEffect(() => {
     setIsUsingFallback(false);
     setFallbackReason('');
+    // Clear any prior model's config so it can't leak into the next estimate.
+    setHfConfig(null);
 
-    // Skip HF fetch for supported and catalog models — we know they work
-    if (getAppConfig().testedModels.includes(model) || aicModels.includes(model)) {
+    // Skip HF fetch only for catalog models — AIC resolves those itself.
+    // Tested models outside the catalog still need their HF config sent along.
+    if (!needsHfConfig(model, aicModels)) {
       setIsFetchingConfig(false);
       return;
     }
@@ -319,7 +313,9 @@ export default function QuickEstimate() {
           vram_gb: currentAicGpu?.vramGb ?? null,
           gpu_memory_utilization: currentAicGpu?.gpuMemoryUtilization,
           backend_version: backendVersion || undefined,
-          hf_model_config: hfConfig as Record<string, unknown> | null,
+          // Only send the config for models AIC can't resolve itself; guards
+          // against a stale config from a previously selected model.
+          hf_model_config: needsHfConfig(model, aicModels) ? (hfConfig as Record<string, unknown> | null) : null,
           kvcache_quant_mode: testKVCachePrecision === 'FP8' ? 'fp8' :
                              testKVCachePrecision === 'NVFP4' ? 'nvfp4' : null,
           gemm_quant_mode: testWeightPrecision === 'FP8' ? 'fp8' :

--- a/app/performance/PerformanceEstimate.tsx
+++ b/app/performance/PerformanceEstimate.tsx
@@ -251,12 +251,17 @@ export default function QuickEstimate() {
       return;
     }
 
+    let cancelled = false;
     const fetchConfig = async () => {
       setIsFetchingConfig(true);
       console.log('🔄 Fetching config from HuggingFace for:', model);
       console.log('🔑 HF Token:', hfToken ? `Provided (${hfToken.substring(0, 7)}...)` : 'Not provided');
 
       const result = await fetchModelConfig(model, hfToken);
+
+      // Ignore a response for a model the user has since moved away from — the
+      // superseding effect run owns the loading + config state.
+      if (cancelled) return;
 
       if (result.success && result.config) {
         setHfConfig(result.config);
@@ -276,7 +281,7 @@ export default function QuickEstimate() {
 
     // Debounce to avoid fetching while user is typing
     const timer = setTimeout(fetchConfig, 500);
-    return () => clearTimeout(timer);
+    return () => { cancelled = true; clearTimeout(timer); };
   }, [model, hfToken, hydrated, aicModels]);
 
   // Auto-run calculation when inputs change — calls AIC /recommend API

--- a/app/recommend/AdvancedEstimate.tsx
+++ b/app/recommend/AdvancedEstimate.tsx
@@ -246,6 +246,7 @@ export default function AdvancedEstimate() {
   React.useEffect(() => {
     if (catalogLoading) { setModelStatus('idle'); return; }
     setHfConfig(null);
+    let cancelled = false;
     const timer = setTimeout(() => {
       if (!model.includes('/')) { setModelStatus('idle'); return; }
       const isTested = getAppConfig().testedModels.includes(model);
@@ -255,6 +256,8 @@ export default function AdvancedEstimate() {
       }
       setModelStatus('fetching');
       fetchModelConfig(model, hfToken).then(r => {
+        // Ignore a response for a model the user has since moved away from.
+        if (cancelled) return;
         if (r.success && r.config) {
           setHfConfig(r.config as Record<string, unknown>);
           // Tested models keep their blue "supported" status even though we
@@ -267,7 +270,7 @@ export default function AdvancedEstimate() {
         }
       });
     }, 500);
-    return () => clearTimeout(timer);
+    return () => { cancelled = true; clearTimeout(timer); };
   }, [model, hfToken, MODEL_OPTIONS, catalogLoading, hydrated]);
 
   // Fetch live pricing

--- a/app/recommend/AdvancedEstimate.tsx
+++ b/app/recommend/AdvancedEstimate.tsx
@@ -23,6 +23,7 @@ import { getAppConfig } from '@/lib/app-config';
 import { DEFAULT_WORKLOAD, type WorkloadPreset } from '@/lib/workload-presets';
 import { ModelInput } from '@/components/ui/ModelInput';
 import { ComboBox, type ComboBoxItem } from '@/components/ModelComboBox/ModelComboBox';
+import { buildModelItems, needsHfConfig } from '@/lib/model-options';
 import { GpuSystemInput } from '@/components/ui/GpuSystemInput';
 
 function modelSuggestions(): string {
@@ -142,21 +143,12 @@ export default function AdvancedEstimate() {
   const { modelOptions: aicModels, gpuOptions: aicGpus, isLoading: catalogLoading } = useAicCatalog();
   const MODEL_OPTIONS = aicModels;
 
-  const modelItems: ComboBoxItem[] = React.useMemo(() =>
-    aicModels.map(m => {
-      const slash = m.indexOf('/');
-      const isTested = getAppConfig().testedModels.includes(m);
-      return {
-        value: m,
-        label: m,
-        group: slash > 0 ? m.slice(0, slash) : '',
-        isTested,
-        inCatalog: true,
-      };
-    }), [aicModels]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- hydrated gates config.json readiness
+  const modelItems: ComboBoxItem[] = React.useMemo(() => buildModelItems(aicModels), [aicModels, hydrated]);
 
   // Input state
   const [model, setModel] = React.useState('');
+  const [hfConfig, setHfConfig] = React.useState<Record<string, unknown> | null>(null);
 
   // Set model from settings after context has loaded from localStorage
   const modelFromSettings = React.useRef(false);
@@ -248,17 +240,31 @@ export default function AdvancedEstimate() {
     setPrefix(isNaN(n) ? 0 : n);
   };
 
-  // Model status check + fetch HF config
+  // Model status check + fetch HF config. Catalog models resolve server-side;
+  // everything else (incl. tested models outside the catalog) needs its HF
+  // config.json fetched and stored so it can be sent to AIC on calculate.
   React.useEffect(() => {
     if (catalogLoading) { setModelStatus('idle'); return; }
+    setHfConfig(null);
     const timer = setTimeout(() => {
       if (!model.includes('/')) { setModelStatus('idle'); return; }
-      if (getAppConfig().testedModels.includes(model)) { setModelStatus('supported'); return; }
-      const inCatalog = MODEL_OPTIONS.includes(model);
-      if (inCatalog) { setModelStatus('catalog'); return; }
+      const isTested = getAppConfig().testedModels.includes(model);
+      if (!needsHfConfig(model, MODEL_OPTIONS)) {
+        setModelStatus(isTested ? 'supported' : 'catalog');
+        return;
+      }
       setModelStatus('fetching');
       fetchModelConfig(model, hfToken).then(r => {
-        setModelStatus(r.success && r.config ? 'fetched' : 'error');
+        if (r.success && r.config) {
+          setHfConfig(r.config as Record<string, unknown>);
+          // Tested models keep their blue "supported" status even though we
+          // fetched the config from HF; others show the neutral "fetched".
+          setModelStatus(isTested ? 'supported' : 'fetched');
+        } else {
+          // Tested models stay blue — AIC can still resolve them from HF
+          // server-side when we send no model_config.
+          setModelStatus(isTested ? 'supported' : 'error');
+        }
       });
     }, 500);
     return () => clearTimeout(timer);
@@ -292,6 +298,8 @@ export default function AdvancedEstimate() {
       tpot, target_concurrency: targetConcurrency, prefix,
       ...(requestLatency != null ? { request_latency: requestLatency } : {}),
       backend: inferenceBackend,
+      // Send the HF config for models AIC can't resolve from its catalog.
+      ...(needsHfConfig(model, MODEL_OPTIONS) && hfConfig ? { model_config: hfConfig } : {}),
     });
   };
 

--- a/components/ModelComboBox/ModelComboBox.module.css
+++ b/components/ModelComboBox/ModelComboBox.module.css
@@ -75,18 +75,6 @@
   font-style: normal;
 }
 
-/* ─── Quantization checkboxes ─── */
-.quantRow {
-  margin-top: 6px;
-}
-
-.quantRow :global(.pf-v5-c-check__label) {
-  font-size: 12px;
-  font-family: var(--mono, monospace);
-  font-weight: 500;
-  color: var(--t2, #3c3f42);
-}
-
 /* ─── Helper text ─── */
 .helperText {
   font-size: 12px;
@@ -119,7 +107,7 @@
 
 .testedBadge,
 .catalogBadge,
-.hfTokenBadge {
+.hfBadge {
   font-size: 10px;
   font-weight: 600;
   font-family: var(--mono, monospace);
@@ -140,9 +128,9 @@
   color: #155724;
 }
 
-.hfTokenBadge {
-  background-color: #fff3cd;
-  color: #856404;
+.hfBadge {
+  background-color: #fdf0d5;
+  color: #8a6d00;
 }
 
 .selectedBadges {

--- a/components/ModelComboBox/ModelComboBox.module.css
+++ b/components/ModelComboBox/ModelComboBox.module.css
@@ -108,7 +108,7 @@
 .testedBadge,
 .catalogBadge,
 .hfBadge {
-  font-size: 10px;
+  font-size: 11.5px;
   font-weight: 600;
   font-family: var(--mono, monospace);
   padding: 2px 6px;

--- a/components/ModelComboBox/ModelComboBox.module.css
+++ b/components/ModelComboBox/ModelComboBox.module.css
@@ -136,11 +136,17 @@
 }
 
 .catalogBadge {
-  background-color: #f5f5f5;
-  color: #54585c;
+  background-color: #d4edda;
+  color: #155724;
 }
 
 .hfTokenBadge {
-  background-color: #fff4e6;
-  color: #9d5d00;
+  background-color: #fff3cd;
+  color: #856404;
+}
+
+.selectedBadges {
+  display: flex;
+  gap: 4px;
+  margin-right: 8px;
 }

--- a/components/ModelComboBox/ModelComboBox.tsx
+++ b/components/ModelComboBox/ModelComboBox.tsx
@@ -3,7 +3,6 @@
 import * as React from 'react'
 import {
   Switch,
-  Checkbox,
   Select,
   SelectList,
   SelectGroup,
@@ -24,7 +23,7 @@ export interface ComboBoxItem {
   group: string
   isTested?: boolean
   inCatalog?: boolean
-  requiresHfToken?: boolean
+  isHuggingFace?: boolean
 }
 
 interface ComboBoxProps {
@@ -56,22 +55,6 @@ function groupItems(items: ComboBoxItem[]): GroupedItems[] {
   })).toSorted((a, b) => a.group.localeCompare(b.group))
 }
 
-const FP8_SUFFIX_RE = /-FP8(-\w+)*$/
-
-const NVFP4_SUFFIX_RE = /-NVFP4(-\w+)*$/
-
-function isFp8Model(modelId: string): boolean {
-  return FP8_SUFFIX_RE.test(modelId)
-}
-
-function isNvfp4Model(modelId: string): boolean {
-  return NVFP4_SUFFIX_RE.test(modelId)
-}
-
-function toBaseModelId(modelId: string): string {
-  return modelId.replace(FP8_SUFFIX_RE, '').replace(NVFP4_SUFFIX_RE, '')
-}
-
 function suggestedNames(): string {
   const names = getAppConfig().suggestedModelNames
   return names.length > 0 ? names.join(', ') : 'Nemotron, DeepSeek V4, Gemma 4, Kimi'
@@ -86,46 +69,19 @@ export function ComboBox({ value, onChange, items, placeholder, id, allowCustom 
   const textInputRef = React.useRef<HTMLInputElement>(null)
   const toggleRef = React.useRef<HTMLDivElement>(null)
 
-  const variantMap = React.useMemo(() => {
-    const map = new Map<string, { fp8?: string; nvfp4?: string }>()
-    for (const item of items) {
-      const base = toBaseModelId(item.value)
-      if (base === item.value) continue
-      if (!map.has(base)) map.set(base, {})
-      const entry = map.get(base)!
-      if (isFp8Model(item.value)) entry.fp8 = item.value
-      else if (isNvfp4Model(item.value)) entry.nvfp4 = item.value
-    }
-    return map
-  }, [items])
+  const validatedItems = React.useMemo(() =>
+    supportedModels ? items.filter(i => supportedModels.includes(i.value)) : items,
+    [items, supportedModels])
 
-  const currentBase = toBaseModelId(value)
-  const activeVariant: 'fp8' | 'nvfp4' | null = isFp8Model(value) ? 'fp8' : isNvfp4Model(value) ? 'nvfp4' : null
-  const variants = variantMap.get(currentBase)
-
-  const baseItems = React.useMemo(() =>
-    items.filter(i => !isFp8Model(i.value) && !isNvfp4Model(i.value)),
-    [items])
-
-  const validatedBaseItems = React.useMemo(() =>
-    supportedModels ? baseItems.filter(i => {
-      if (supportedModels.includes(i.value)) return true
-      const v = variantMap.get(i.value)
-      if (!v) return false
-      return (v.fp8 != null && supportedModels.includes(v.fp8)) ||
-             (v.nvfp4 != null && supportedModels.includes(v.nvfp4))
-    }) : baseItems,
-    [baseItems, supportedModels, variantMap])
-
-  const activeItems = supportedOnly ? validatedBaseItems : baseItems
+  const activeItems = supportedOnly ? validatedItems : items
   const wasAutoReplacedRef = React.useRef(false)
 
   const handleToggle = (_: React.FormEvent, checked: boolean) => {
     setSupportedOnly(checked)
     if (checked) {
       prevModel.current = value
-      if (!validatedBaseItems.some(i => i.value === currentBase) && validatedBaseItems.length > 0) {
-        onChange(validatedBaseItems[0].value)
+      if (!validatedItems.some(i => i.value === value) && validatedItems.length > 0) {
+        onChange(validatedItems[0].value)
         wasAutoReplacedRef.current = true
       } else {
         wasAutoReplacedRef.current = false
@@ -139,7 +95,7 @@ export function ComboBox({ value, onChange, items, placeholder, id, allowCustom 
     }
   }
 
-  const selectedItem = activeItems.find(i => i.value === currentBase)
+  const selectedItem = activeItems.find(i => i.value === value)
 
   const filtered = React.useMemo(() => {
     if (!filter) return activeItems
@@ -240,17 +196,7 @@ export function ComboBox({ value, onChange, items, placeholder, id, allowCustom 
     }
   }
 
-  function handleQuantToggle(variant: 'fp8' | 'nvfp4') {
-    return (_: React.FormEvent<HTMLInputElement>, checked: boolean) => {
-      if (checked && variants?.[variant]) {
-        onChange(variants[variant]!)
-      } else {
-        onChange(currentBase)
-      }
-    }
-  }
-
-  const displayValue = open ? filter : (activeVariant ? value : (selectedItem?.label ?? value))
+  const displayValue = open ? filter : (selectedItem?.label ?? value)
 
   const toggle = (tRef: React.RefObject<HTMLDivElement | HTMLButtonElement>) => (
     <MenuToggle
@@ -283,7 +229,7 @@ export function ComboBox({ value, onChange, items, placeholder, id, allowCustom 
             <div className={styles.selectedBadges}>
               {selectedItem.isTested && <span className={styles.testedBadge}>tested</span>}
               {selectedItem.inCatalog && !selectedItem.isTested && <span className={styles.catalogBadge}>in catalog</span>}
-              {selectedItem.requiresHfToken && <span className={styles.hfTokenBadge}>requires HF token</span>}
+              {selectedItem.isHuggingFace && !selectedItem.isTested && !selectedItem.inCatalog && <span className={styles.hfBadge}>hugging face</span>}
             </div>
           )}
           {value && !open && (
@@ -345,7 +291,7 @@ export function ComboBox({ value, onChange, items, placeholder, id, allowCustom 
                     <div className={styles.badges}>
                       {item.isTested && <span className={styles.testedBadge}>tested</span>}
                       {item.inCatalog && !item.isTested && <span className={styles.catalogBadge}>in catalog</span>}
-                      {item.requiresHfToken && <span className={styles.hfTokenBadge}>requires HF token</span>}
+                      {item.isHuggingFace && !item.isTested && !item.inCatalog && <span className={styles.hfBadge}>hugging face</span>}
                     </div>
                   </div>
                 </SelectOption>
@@ -377,27 +323,6 @@ export function ComboBox({ value, onChange, items, placeholder, id, allowCustom 
           )}
         </SelectList>
       </Select>
-
-      {variants && (variants.fp8 || variants.nvfp4) && (
-        <div className={styles.quantRow}>
-          {variants.fp8 && (
-            <Checkbox
-              id={id ? `${id}-fp8` : 'fp8-toggle'}
-              label="Use FP8 quantization"
-              isChecked={activeVariant === 'fp8'}
-              onChange={handleQuantToggle('fp8')}
-            />
-          )}
-          {variants.nvfp4 && (
-            <Checkbox
-              id={id ? `${id}-nvfp4` : 'nvfp4-toggle'}
-              label="Use NVFP4 quantization"
-              isChecked={activeVariant === 'nvfp4'}
-              onChange={handleQuantToggle('nvfp4')}
-            />
-          )}
-        </div>
-      )}
 
       {supportedModels && (
         <div className={styles.helperText}>

--- a/components/ModelComboBox/ModelComboBox.tsx
+++ b/components/ModelComboBox/ModelComboBox.tsx
@@ -279,6 +279,13 @@ export function ComboBox({ value, onChange, items, placeholder, id, allowCustom 
           aria-activedescendant={focusIndex >= 0 ? `${id}-opt-${focusIndex}` : undefined}
         />
         <TextInputGroupUtilities>
+          {value && !open && selectedItem && (
+            <div className={styles.selectedBadges}>
+              {selectedItem.isTested && <span className={styles.testedBadge}>tested</span>}
+              {selectedItem.inCatalog && !selectedItem.isTested && <span className={styles.catalogBadge}>in catalog</span>}
+              {selectedItem.requiresHfToken && <span className={styles.hfTokenBadge}>requires HF token</span>}
+            </div>
+          )}
           {value && !open && (
             <Button variant="plain" onClick={handleClear} aria-label="Clear selection" className={styles.clearBtn}>
               <TimesIcon />

--- a/contexts/GpuSizerContext.tsx
+++ b/contexts/GpuSizerContext.tsx
@@ -15,6 +15,7 @@ interface GpuSizerParams {
   target_request_rate?: number;
   request_latency?: number;
   prefix?: number;
+  model_config?: Record<string, unknown> | null;
 }
 
 interface GpuSizerState {
@@ -97,6 +98,7 @@ export function GpuSizerProvider({ children }: { children: React.ReactNode }) {
     }
     if (p.request_latency != null) requestBody.request_latency = p.request_latency;
     if (p.prefix != null && p.prefix > 0) requestBody.prefix = p.prefix;
+    if (p.model_config != null) requestBody.model_config = p.model_config;
 
     setParams(p);
     setIsLoading(true);

--- a/lib/__tests__/model-options.test.ts
+++ b/lib/__tests__/model-options.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { buildModelItems, needsHfConfig } from '../model-options'
+import type { AppConfig } from '../app-config'
+
+// buildModelItems reads testedModels + huggingFaceModels from getAppConfig().
+vi.mock('../app-config', () => ({ getAppConfig: vi.fn() }))
+import { getAppConfig } from '../app-config'
+const mockGetAppConfig = vi.mocked(getAppConfig)
+
+const BASE: AppConfig = {
+  defaultModel: '',
+  defaultSystem: '',
+  defaultOpenModel: '',
+  defaultFrontierModel: '',
+  defaultBackend: 'vllm',
+  backendVersions: {},
+  testedModels: [],
+  huggingFaceModels: [],
+  suggestedModelNames: [],
+  modelRequestUrl: '',
+  workloadPresets: [],
+}
+
+const AIC_MODELS = ['org-a/catalog-model', 'org-a/tested-in-catalog', 'plain-model']
+
+beforeEach(() => {
+  mockGetAppConfig.mockReturnValue({
+    ...BASE,
+    testedModels: ['org-a/tested-in-catalog', 'org-b/tested-only'],
+    huggingFaceModels: ['org-c/hf-only', 'org-a/tested-in-catalog'],
+  })
+})
+
+describe('buildModelItems', () => {
+  it('flags a catalog-only model as inCatalog', () => {
+    const item = buildModelItems(AIC_MODELS).find(i => i.value === 'org-a/catalog-model')!
+    expect(item).toMatchObject({ inCatalog: true, isTested: false, isHuggingFace: false })
+  })
+
+  it('flags a tested model that is also in the catalog', () => {
+    const item = buildModelItems(AIC_MODELS).find(i => i.value === 'org-a/tested-in-catalog')!
+    // Present in all three sources → all flags set, but appears exactly once.
+    expect(item).toMatchObject({ inCatalog: true, isTested: true, isHuggingFace: true })
+  })
+
+  it('includes a tested model that is NOT in the catalog', () => {
+    const item = buildModelItems(AIC_MODELS).find(i => i.value === 'org-b/tested-only')
+    expect(item).toBeDefined()
+    expect(item).toMatchObject({ inCatalog: false, isTested: true, isHuggingFace: false })
+  })
+
+  it('flags a hugging-face-only model', () => {
+    const item = buildModelItems(AIC_MODELS).find(i => i.value === 'org-c/hf-only')!
+    expect(item).toMatchObject({ inCatalog: false, isTested: false, isHuggingFace: true })
+  })
+
+  it('dedupes models present in multiple sources', () => {
+    const items = buildModelItems(AIC_MODELS)
+    const dupes = items.filter(i => i.value === 'org-a/tested-in-catalog')
+    expect(dupes).toHaveLength(1)
+  })
+
+  it('derives group from the org prefix, empty when no slash', () => {
+    const items = buildModelItems(AIC_MODELS)
+    expect(items.find(i => i.value === 'org-a/catalog-model')!.group).toBe('org-a')
+    expect(items.find(i => i.value === 'plain-model')!.group).toBe('')
+  })
+
+  it('lists catalog models before tested-only and hf-only models', () => {
+    const values = buildModelItems(AIC_MODELS).map(i => i.value)
+    expect(values.indexOf('org-a/catalog-model')).toBeLessThan(values.indexOf('org-b/tested-only'))
+    expect(values.indexOf('org-b/tested-only')).toBeLessThan(values.indexOf('org-c/hf-only'))
+  })
+})
+
+describe('needsHfConfig', () => {
+  it('is false for a model in the AIC catalog', () => {
+    expect(needsHfConfig('org-a/catalog-model', AIC_MODELS)).toBe(false)
+  })
+
+  it('is true for a model outside the catalog (incl. tested-only)', () => {
+    expect(needsHfConfig('org-b/tested-only', AIC_MODELS)).toBe(true)
+    expect(needsHfConfig('someone/random-model', AIC_MODELS)).toBe(true)
+  })
+
+  it('is false for an empty model string', () => {
+    expect(needsHfConfig('', AIC_MODELS)).toBe(false)
+  })
+})

--- a/lib/api/__tests__/gpu-sizer.test.ts
+++ b/lib/api/__tests__/gpu-sizer.test.ts
@@ -70,6 +70,14 @@ describe('GpuSizerRequestSchema', () => {
     expect(result.success).toBe(false)
   })
 
+  it('accepts a model_config object', () => {
+    const result = GpuSizerRequestSchema.safeParse({
+      ...VALID_REQUEST,
+      model_config: { hidden_size: 8192, architectures: ['LlamaForCausalLM'] },
+    })
+    expect(result.success).toBe(true)
+  })
+
   it('accepts target_request_rate instead of target_concurrency', () => {
     const { target_concurrency, ...rest } = VALID_REQUEST
     const result = GpuSizerRequestSchema.safeParse({ ...rest, target_request_rate: 10 })
@@ -177,6 +185,27 @@ describe('callGpuSizer', () => {
     expect(sentBody.database_mode).toBe('HYBRID')
     expect(sentBody).not.toHaveProperty('username')
     expect(sentBody).not.toHaveProperty('password')
+  })
+
+  it('forwards model_config to the upstream request when present', async () => {
+    const mockFetch = mockFetchOk(EXTERNAL_RESPONSE)
+    vi.stubGlobal('fetch', mockFetch)
+
+    const model_config = { hidden_size: 8192, architectures: ['LlamaForCausalLM'] }
+    await callGpuSizer({ ...VALID_REQUEST, model_config })
+
+    const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body)
+    expect(sentBody.model_config).toEqual(model_config)
+  })
+
+  it('omits model_config from the upstream request when absent', async () => {
+    const mockFetch = mockFetchOk(EXTERNAL_RESPONSE)
+    vi.stubGlobal('fetch', mockFetch)
+
+    await callGpuSizer(VALID_REQUEST)
+
+    const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body)
+    expect(sentBody).not.toHaveProperty('model_config')
   })
 
   it('returns AIC_NOT_CONFIGURED when API URL is missing', async () => {

--- a/lib/api/__tests__/kv-cache-calc.test.ts
+++ b/lib/api/__tests__/kv-cache-calc.test.ts
@@ -69,6 +69,14 @@ describe('KvCacheCalcRequestSchema', () => {
     expect(result.success).toBe(false)
   })
 
+  it('accepts a model_config object', () => {
+    const result = KvCacheCalcRequestSchema.safeParse({
+      ...VALID_REQUEST,
+      model_config: { hidden_size: 8192, architectures: ['LlamaForCausalLM'] },
+    })
+    expect(result.success).toBe(true)
+  })
+
   it('applies defaults for optional fields', () => {
     const result = KvCacheCalcRequestSchema.safeParse({
       model_path: 'test/model',
@@ -165,6 +173,18 @@ describe('callKvCacheCalc', () => {
     expect(sentBody).not.toHaveProperty('moe_tp_size')
     expect(sentBody).not.toHaveProperty('moe_ep_size')
     expect(sentBody).not.toHaveProperty('backend_version')
+    expect(sentBody).not.toHaveProperty('model_config')
+  })
+
+  it('forwards model_config to the upstream request when present', async () => {
+    const mockFetch = mockFetchOk(EXTERNAL_RESPONSE)
+    vi.stubGlobal('fetch', mockFetch)
+
+    const model_config = { hidden_size: 8192, architectures: ['LlamaForCausalLM'] }
+    await callKvCacheCalc({ ...VALID_REQUEST, model_config })
+
+    const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body)
+    expect(sentBody.model_config).toEqual(model_config)
   })
 
   it('returns AIC_NOT_CONFIGURED when API URL is missing', async () => {

--- a/lib/api/gpu-sizer.ts
+++ b/lib/api/gpu-sizer.ts
@@ -96,6 +96,7 @@ export async function callGpuSizer(
   if (request.target_concurrency != null) externalPayload.target_concurrency = request.target_concurrency
   if (request.request_latency != null) externalPayload.request_latency = request.request_latency
   if (request.prefix != null) externalPayload.prefix = request.prefix
+  if (request.model_config != null) externalPayload.model_config = request.model_config
 
   let response: Response
   try {

--- a/lib/api/kv-cache-calc.ts
+++ b/lib/api/kv-cache-calc.ts
@@ -85,6 +85,7 @@ export async function callKvCacheCalc(
   if (request.backend_version) externalPayload.backend_version = request.backend_version
   if (request.moe_tp_size != null) externalPayload.moe_tp_size = request.moe_tp_size
   if (request.moe_ep_size != null) externalPayload.moe_ep_size = request.moe_ep_size
+  if (request.model_config != null) externalPayload.model_config = request.model_config
 
   let response: Response
   try {

--- a/lib/api/schemas.ts
+++ b/lib/api/schemas.ts
@@ -43,6 +43,8 @@ export const GpuSizerRequestSchema = z.object({
   prefix: z.number().int().min(0).default(0),
   database_mode: z.enum(['HYBRID', 'SILICON', 'EMPIRICAL', 'SOL']).default('HYBRID'),
   top_n: z.number().int().min(1).max(20).default(5),
+  // HF config.json for models AIC can't resolve from its catalog (nullish = resolve from HF).
+  model_config: z.record(z.string(), z.unknown()).nullish(),
 }).strict().refine(
   data => (data.target_request_rate != null) !== (data.target_concurrency != null),
   { message: 'Exactly one of target_request_rate or target_concurrency must be provided' }
@@ -65,6 +67,8 @@ export const KvCacheCalcRequestSchema = z.object({
   moe_ep_size: z.number().int().positive().nullish(),
   memory_fraction_kind: z.enum(['of_total', 'of_free']).default('of_total'),
   memory_fraction_value: z.number().min(0).max(1).default(1.0),
+  // HF config.json for models AIC can't resolve from its catalog (nullish = resolve from HF).
+  model_config: z.record(z.string(), z.unknown()).nullish(),
 }).strict()
 
 export type KvCacheCalcRequest = z.infer<typeof KvCacheCalcRequestSchema>

--- a/lib/app-config.ts
+++ b/lib/app-config.ts
@@ -8,6 +8,7 @@ export interface AppConfig {
   defaultBackend: string;
   backendVersions: Record<string, string>;
   testedModels: string[];
+  huggingFaceModels: string[];
   suggestedModelNames: string[];
   modelRequestUrl: string;
   workloadPresets: WorkloadPreset[];
@@ -26,6 +27,7 @@ const FALLBACK: AppConfig = {
     'sglang': '0.5.17',
   },
   testedModels: [],
+  huggingFaceModels: [],
   suggestedModelNames: [],
   modelRequestUrl: '',
   workloadPresets: [],
@@ -47,6 +49,7 @@ export async function loadAppConfig(): Promise<AppConfig> {
       defaultBackend: data.defaultBackend ?? FALLBACK.defaultBackend,
       backendVersions: data.backendVersions ?? FALLBACK.backendVersions,
       testedModels: data.testedModels ?? FALLBACK.testedModels,
+      huggingFaceModels: data.huggingFaceModels ?? FALLBACK.huggingFaceModels,
       suggestedModelNames: data.suggestedModelNames ?? FALLBACK.suggestedModelNames,
       modelRequestUrl: data.modelRequestUrl ?? FALLBACK.modelRequestUrl,
       workloadPresets: data.workloadPresets ?? FALLBACK.workloadPresets,

--- a/lib/model-options.ts
+++ b/lib/model-options.ts
@@ -1,0 +1,46 @@
+import type { ComboBoxItem } from '@/components/ModelComboBox/ModelComboBox'
+import { getAppConfig } from '@/lib/app-config'
+
+/**
+ * Build the model dropdown items from the three model sources, deduped:
+ *   1. AIC catalog  (from the /models REST endpoint)   → "in catalog" (green)
+ *   2. Tested models (config.testedModels)             → "tested" (blue)
+ *   3. Hugging Face models (config.huggingFaceModels)  → "hugging face" (gold)
+ *
+ * A model can belong to more than one source; the flags are set independently
+ * and the badge is chosen by priority (tested > catalog > hugging face) at
+ * render time. Order: catalog first, then tested-not-in-catalog, then any
+ * remaining HF-listed models.
+ */
+export function buildModelItems(aicModels: string[]): ComboBoxItem[] {
+  const config = getAppConfig()
+  const catalog = new Set(aicModels)
+  const tested = new Set(config.testedModels)
+  const hf = new Set(config.huggingFaceModels)
+
+  const seen = new Set<string>()
+  const items: ComboBoxItem[] = []
+  for (const m of [...aicModels, ...config.testedModels, ...config.huggingFaceModels]) {
+    if (seen.has(m)) continue
+    seen.add(m)
+    const slash = m.indexOf('/')
+    items.push({
+      value: m,
+      label: m,
+      group: slash > 0 ? m.slice(0, slash) : '',
+      isTested: tested.has(m),
+      inCatalog: catalog.has(m),
+      isHuggingFace: hf.has(m),
+    })
+  }
+  return items
+}
+
+/**
+ * Whether a model needs its config.json fetched from Hugging Face and sent to
+ * AIC as `model_config`. True for any model the AIC catalog can't resolve on
+ * its own — including tested models that live outside the catalog.
+ */
+export function needsHfConfig(model: string, aicModels: string[]): boolean {
+  return !!model && !aicModels.includes(model)
+}

--- a/public/config.json
+++ b/public/config.json
@@ -21,6 +21,9 @@
     "RedHatAI/GLM-5.2-FP8",
     "moonshotai/Kimi-K2.5"
   ],
+  "huggingFaceModels": [
+    "RedHatAI/GLM-5.2-NVFP4-FP8"
+  ],
   "modelRequestUrl": "https://github.com/redhat-performance/configiq/issues/new?labels=model-request&title=[Model+Request]+",
   "workloadPresets": [
     { "key": "chat",           "label": "Interactive chat",  "isl":  8192, "osl":   512, "ttft":   800, "tpot":  30, "concurrency":  64, "prefix":  2048 },

--- a/public/config.json.testing
+++ b/public/config.json.testing
@@ -1,0 +1,30 @@
+{
+  "defaultModel": "Qwen/Qwen3-32B",
+  "defaultSystem": "h200_sxm",
+  "defaultOpenModel": "Qwen/Qwen3-32B",
+  "defaultFrontierModel": "claude-fable-5",
+  "defaultBackend": "vllm",
+  "backendVersions": {
+    "vllm": "0.24.0",
+    "tensorrt-llm": "11.2",
+    "sglang": "0.5.17"
+  },
+  "suggestedModelNames": ["Gemma 4", "Nemotron Super", "DeepSeek V4", "gpt-oss"],
+  "testedModels": [
+    "deepseek-ai/DeepSeek-V4-Pro",
+    "nvidia/Gemma-4-31B-IT-NVFP4",
+    "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8",
+    "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-FP8",
+    "openai/gpt-oss-120b",
+    "zai-org/GLM-5.2-FP8",
+    "moonshotai/Kimi-K2.5"
+  ],
+  "modelRequestUrl": "https://github.com/redhat-performance/configiq/issues/new?labels=model-request&title=[Model+Request]+",
+  "workloadPresets": [
+    { "key": "chat",           "label": "Interactive chat",  "isl":  8192, "osl":   512, "ttft":   800, "tpot":  30, "concurrency":  64, "prefix":  2048 },
+    { "key": "rag",            "label": "RAG / Search",      "isl": 16384, "osl":   512, "ttft":  1500, "tpot":  40, "concurrency":  32, "prefix":  4096 },
+    { "key": "agentic-coding", "label": "Agentic / Coding",  "isl": 32768, "osl":  2048, "ttft":  3000, "tpot":  50, "concurrency":  16, "prefix":  8192 },
+    { "key": "batch",          "label": "Batch / offline",   "isl": 65536, "osl":  4096, "ttft": 10000, "tpot": 100, "concurrency": 256, "prefix":     0 },
+    { "key": "voice",          "label": "Voice / real-time", "isl":   512, "osl":   128, "ttft":   200, "tpot":  15, "concurrency": 128, "prefix":     0 }
+  ]
+}


### PR DESCRIPTION
## Summary

Two related improvements to the model dropdown:

1. **Selected-model status badges** (`fix: Show status badges on selected model in dropdown`) — surfaces the tested / in-catalog / HF badges on the *selected* model display, so users can see a model's status without opening the dropdown.
2. **Hugging Face models as a config-driven dropdown source** (`feat: Add Hugging Face models…`) — adds a `huggingFaceModels` list to `public/config.json`, shown in the dropdowns with a gold **hugging face** badge (example: `RedHatAI/GLM-5.2-NVFP4-FP8`), and wires the HF `config.json` (`model_config`) through to the Recommend and KV Cache sizing paths.

## What changed

### Selected-model badges
- Render tested/in-catalog badges on the selected model in `ModelComboBox`, matching the in-dropdown badge styling.

### Hugging Face models source
- **Union model list** — dropdowns build from `catalog ∪ tested ∪ huggingFaceModels`, deduped (`lib/model-options.ts`). Tested models that live *outside* the AIC catalog now appear and keep their blue **tested** badge.
- **Decouple badge from lookup** — badge = provenance (`tested > catalog > hugging face`); the HF `config.json` lookup fires iff a model is **not in the catalog** (the `/models` endpoint is the source of truth), regardless of tested/HF status.
- **`model_config` plumbing** — added to the strict Zod schemas (`GpuSizerRequestSchema`, `KvCacheCalcRequestSchema`) and forwarded by the `gpu-sizer` and `kv-cache-calc` clients. Previously only the Performance page sent it; now Recommend and KV Cache do too. The AIC backend already accepts `model_config` on `/recommend`, `/estimate`, and `/memory`.
- **Removed quantization-variant folding** from `ModelComboBox` (FP8/NVFP4 checkboxes) — the mechanism hid quantized IDs (why `…-NVFP4-FP8` never showed) and caused other issues. Every model, including quantized variants, is now a standalone dropdown entry. Removed the dead `requiresHfToken` field.
- **Bug fix** — reset stale `hfConfig` on the Performance page when the model changes and guard the estimate send, so a previously selected model's config can't leak into the next request. (Found during adversarial review; Recommend/KV Cache already handled this.)

## Tests

- `lib/__tests__/model-options.test.ts` — `buildModelItems` (flags, dedup, ordering, group parsing) and `needsHfConfig`.
- `model_config` schema-acceptance + client-forwarding tests for both `/recommend` and `/memory`.
- Full suite: **91 passing** (was 76). `type-check` and `lint` clean.

## Notes / trade-offs

- The "Tested only" toggle now matches exact model IDs rather than "base model has a tested variant" — a direct consequence of removing the quant folding. `testedModels` already lists exact quantized IDs, so behavior is correct.
- Clicking Calculate within the 500ms debounce (before the HF fetch resolves) sends no `model_config`; AIC falls back to server-side HF resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for Hugging Face models and automatic retrieval of model configuration when needed.
  - GPU sizing, KV-cache calculations, and performance estimates now use model configuration data for external models.
  - Expanded model selection with catalog, tested, and Hugging Face models, including deduplication and source badges.
  - Added workload presets and additional model defaults to configuration.
- **UI Updates**
  - Model variants now appear as independent selectable options.
  - Updated badge styling and Hugging Face labels in the model selector.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->