### PR TITLE
chore: Rename GpuSizer nomenclature to Recommend

### DIFF
--- a/app/api/recommend/route.ts
+++ b/app/api/recommend/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { GpuSizerRequestSchema } from '@/lib/api/schemas'
-import { callGpuSizer, generateRequestId } from '@/lib/api/gpu-sizer'
+import { RecommendRequestSchema } from '@/lib/api/schemas'
+import { callRecommend, generateRequestId } from '@/lib/api/recommend'
 
 const ERROR_STATUS_MAP: Record<string, number> = {
   INVALID_REQUEST: 400,
@@ -70,8 +70,8 @@ export async function POST(req: NextRequest) {
       return proxyToAic(body, include)
     }
 
-    const validated = GpuSizerRequestSchema.parse(body)
-    const result = await callGpuSizer(validated)
+    const validated = RecommendRequestSchema.parse(body)
+    const result = await callRecommend(validated)
 
     if (result.status === 'failed') {
       const httpStatus = ERROR_STATUS_MAP[result.error.code] ?? 500

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -40,7 +40,7 @@ import "@patternfly/react-styles/css/components/Tooltip/tooltip.css";
 import "./globals.css";
 import "./theme.css";
 import { AppShell } from "@/components/layout/AppShell";
-import { GpuSizerProvider } from "@/contexts/GpuSizerContext";
+import { RecommendProvider } from "@/contexts/RecommendContext";
 import { SettingsProvider } from "@/contexts/SettingsContext";
 
 const redHatDisplay = Red_Hat_Display({
@@ -89,11 +89,11 @@ export default function RootLayout({
         />
       </head>
       <body>
-        <GpuSizerProvider>
+        <RecommendProvider>
           <SettingsProvider>
             <AppShell>{children}</AppShell>
           </SettingsProvider>
-        </GpuSizerProvider>
+        </RecommendProvider>
       </body>
     </html>
   );

--- a/app/recommend/AdvancedEstimate.tsx
+++ b/app/recommend/AdvancedEstimate.tsx
@@ -15,7 +15,7 @@ import { InfoStrip, InfoStripAction } from '@/components/ui/InfoStrip';
 
 import styles from './AdvancedEstimate.module.css';
 import { fetchModelConfig } from '@/lib/huggingface/fetch-config';
-import { useGpuSizer } from '@/contexts/GpuSizerContext';
+import { useRecommend } from '@/contexts/RecommendContext';
 import { useAicCatalog } from '@/lib/hooks/useAicCatalog';
 import { useSettings } from '@/contexts/SettingsContext';
 import { useCostings, resolveCloudRate } from '@/lib/hooks/useCostings';
@@ -171,7 +171,7 @@ export default function AdvancedEstimate() {
   const [modelStatus, setModelStatus] = React.useState<'idle' | 'supported' | 'catalog' | 'fetching' | 'fetched' | 'error'>('idle');
 
   // GPU sizer (persistent across navigation)
-  const { isLoading, result, error, errorCode, elapsed, debugRequest, debugResponse, debugStatus, debugDuration, startSizing } = useGpuSizer();
+  const { isLoading, result, error, errorCode, elapsed, debugRequest, debugResponse, debugStatus, debugDuration, startSizing } = useRecommend();
   const [debugOpen, setDebugOpen] = React.useState(false);
 
   // Additional constraints accordion

--- a/contexts/RecommendContext.tsx
+++ b/contexts/RecommendContext.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 import * as React from 'react';
-import type { GpuSizerResult } from '@/lib/api/gpu-sizer';
+import type { RecommendResult } from '@/lib/api/recommend';
 
-interface GpuSizerParams {
+interface RecommendParams {
   model_path: string;
   system: string;
   isl: number;
@@ -18,10 +18,10 @@ interface GpuSizerParams {
   model_config?: Record<string, unknown> | null;
 }
 
-interface GpuSizerState {
-  params: GpuSizerParams | null;
+interface RecommendState {
+  params: RecommendParams | null;
   isLoading: boolean;
-  result: GpuSizerResult | null;
+  result: RecommendResult | null;
   error: string | null;
   errorCode: string | null;
   elapsed: number;
@@ -29,11 +29,11 @@ interface GpuSizerState {
   debugResponse: Record<string, unknown> | null;
   debugStatus: number | null;
   debugDuration: number | null;
-  startSizing: (params: GpuSizerParams) => void;
+  startSizing: (params: RecommendParams) => void;
   reset: () => void;
 }
 
-const GpuSizerContext = React.createContext<GpuSizerState>({
+const RecommendContext = React.createContext<RecommendState>({
   params: null,
   isLoading: false,
   result: null,
@@ -48,10 +48,10 @@ const GpuSizerContext = React.createContext<GpuSizerState>({
   reset: () => {},
 });
 
-export function GpuSizerProvider({ children }: { children: React.ReactNode }) {
-  const [params, setParams] = React.useState<GpuSizerParams | null>(null);
+export function RecommendProvider({ children }: { children: React.ReactNode }) {
+  const [params, setParams] = React.useState<RecommendParams | null>(null);
   const [isLoading, setIsLoading] = React.useState(false);
-  const [result, setResult] = React.useState<GpuSizerResult | null>(null);
+  const [result, setResult] = React.useState<RecommendResult | null>(null);
   const [error, setError] = React.useState<string | null>(null);
   const [errorCode, setErrorCode] = React.useState<string | null>(null);
   const [elapsed, setElapsed] = React.useState(0);
@@ -77,7 +77,7 @@ export function GpuSizerProvider({ children }: { children: React.ReactNode }) {
     return clearTimer;
   }, [isLoading, clearTimer]);
 
-  const startSizing = React.useCallback((p: GpuSizerParams) => {
+  const startSizing = React.useCallback((p: RecommendParams) => {
     if (abortRef.current) abortRef.current.abort();
     const controller = new AbortController();
     abortRef.current = controller;
@@ -132,7 +132,7 @@ export function GpuSizerProvider({ children }: { children: React.ReactNode }) {
           setError(data.error?.message || 'Unknown error');
           setErrorCode(data.error?.code || 'UNKNOWN');
         } else {
-          setResult(data as GpuSizerResult);
+          setResult(data as RecommendResult);
         }
       })
       .catch(err => {
@@ -160,18 +160,18 @@ export function GpuSizerProvider({ children }: { children: React.ReactNode }) {
     setDebugDuration(null);
   }, []);
 
-  const value = React.useMemo<GpuSizerState>(
+  const value = React.useMemo<RecommendState>(
     () => ({ params, isLoading, result, error, errorCode, elapsed, debugRequest, debugResponse, debugStatus, debugDuration, startSizing, reset }),
     [params, isLoading, result, error, errorCode, elapsed, debugRequest, debugResponse, debugStatus, debugDuration, startSizing, reset]
   );
 
   return (
-    <GpuSizerContext.Provider value={value}>
+    <RecommendContext.Provider value={value}>
       {children}
-    </GpuSizerContext.Provider>
+    </RecommendContext.Provider>
   );
 }
 
-export function useGpuSizer(): GpuSizerState {
-  return React.useContext(GpuSizerContext);
+export function useRecommend(): RecommendState {
+  return React.useContext(RecommendContext);
 }

--- a/lib/api/__tests__/recommend.test.ts
+++ b/lib/api/__tests__/recommend.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { GpuSizerRequestSchema } from '../schemas'
-import { callGpuSizer, generateRequestId } from '../gpu-sizer'
-import type { GpuSizerResult, GpuSizerErrorResponse } from '../gpu-sizer'
+import { RecommendRequestSchema } from '../schemas'
+import { callRecommend, generateRequestId } from '../recommend'
+import type { RecommendResult, RecommendErrorResponse } from '../recommend'
 
 // ─── Fixtures ────────────────────────────────────────────────────────────────
 
@@ -49,14 +49,14 @@ function mockFetchOk(data: unknown) {
 
 // ─── Schema Tests ────────────────────────────────────────────────────────────
 
-describe('GpuSizerRequestSchema', () => {
+describe('RecommendRequestSchema', () => {
   it('accepts a valid request', () => {
-    const result = GpuSizerRequestSchema.safeParse(VALID_REQUEST)
+    const result = RecommendRequestSchema.safeParse(VALID_REQUEST)
     expect(result.success).toBe(true)
   })
 
   it('rejects when both target_request_rate and target_concurrency are set', () => {
-    const result = GpuSizerRequestSchema.safeParse({
+    const result = RecommendRequestSchema.safeParse({
       ...VALID_REQUEST,
       target_request_rate: 10,
       target_concurrency: 32,
@@ -66,12 +66,12 @@ describe('GpuSizerRequestSchema', () => {
 
   it('rejects when neither target_request_rate nor target_concurrency is set', () => {
     const { target_concurrency, ...rest } = VALID_REQUEST
-    const result = GpuSizerRequestSchema.safeParse(rest)
+    const result = RecommendRequestSchema.safeParse(rest)
     expect(result.success).toBe(false)
   })
 
   it('accepts a model_config object', () => {
-    const result = GpuSizerRequestSchema.safeParse({
+    const result = RecommendRequestSchema.safeParse({
       ...VALID_REQUEST,
       model_config: { hidden_size: 8192, architectures: ['LlamaForCausalLM'] },
     })
@@ -80,51 +80,51 @@ describe('GpuSizerRequestSchema', () => {
 
   it('accepts target_request_rate instead of target_concurrency', () => {
     const { target_concurrency, ...rest } = VALID_REQUEST
-    const result = GpuSizerRequestSchema.safeParse({ ...rest, target_request_rate: 10 })
+    const result = RecommendRequestSchema.safeParse({ ...rest, target_request_rate: 10 })
     expect(result.success).toBe(true)
   })
 
   it('rejects missing model_path', () => {
     const { model_path, ...rest } = VALID_REQUEST
-    const result = GpuSizerRequestSchema.safeParse(rest)
+    const result = RecommendRequestSchema.safeParse(rest)
     expect(result.success).toBe(false)
   })
 
   it('rejects empty model_path', () => {
-    const result = GpuSizerRequestSchema.safeParse({ ...VALID_REQUEST, model_path: '' })
+    const result = RecommendRequestSchema.safeParse({ ...VALID_REQUEST, model_path: '' })
     expect(result.success).toBe(false)
   })
 
   it('rejects missing system', () => {
     const { system, ...rest } = VALID_REQUEST
-    const result = GpuSizerRequestSchema.safeParse(rest)
+    const result = RecommendRequestSchema.safeParse(rest)
     expect(result.success).toBe(false)
   })
 
   it('rejects zero isl', () => {
-    const result = GpuSizerRequestSchema.safeParse({ ...VALID_REQUEST, isl: 0 })
+    const result = RecommendRequestSchema.safeParse({ ...VALID_REQUEST, isl: 0 })
     expect(result.success).toBe(false)
   })
 
   it('rejects negative osl', () => {
-    const result = GpuSizerRequestSchema.safeParse({ ...VALID_REQUEST, osl: -1 })
+    const result = RecommendRequestSchema.safeParse({ ...VALID_REQUEST, osl: -1 })
     expect(result.success).toBe(false)
   })
 
   it('rejects zero ttft', () => {
-    const result = GpuSizerRequestSchema.safeParse({ ...VALID_REQUEST, ttft: 0 })
+    const result = RecommendRequestSchema.safeParse({ ...VALID_REQUEST, ttft: 0 })
     expect(result.success).toBe(false)
   })
 
   it('rejects unknown fields (strict mode)', () => {
-    const result = GpuSizerRequestSchema.safeParse({ ...VALID_REQUEST, extra: 'nope' })
+    const result = RecommendRequestSchema.safeParse({ ...VALID_REQUEST, extra: 'nope' })
     expect(result.success).toBe(false)
   })
 })
 
 // ─── Service Tests ───────────────────────────────────────────────────────────
 
-describe('callGpuSizer', () => {
+describe('callRecommend', () => {
   beforeEach(() => {
     vi.stubEnv('AICONFIGURATOR_GATEWAY_URL', 'https://aiconfigurator.dev')
   })
@@ -137,10 +137,10 @@ describe('callGpuSizer', () => {
   it('returns a normalized response on success', async () => {
     vi.stubGlobal('fetch', mockFetchOk(EXTERNAL_RESPONSE))
 
-    const result = await callGpuSizer(VALID_REQUEST)
+    const result = await callRecommend(VALID_REQUEST)
 
     expect(result.status).toBe('completed')
-    const r = result as GpuSizerResult
+    const r = result as RecommendResult
     expect(r.requestId).toMatch(/^size_/)
     expect(r.recommendation.gpusNeeded).toBe(4)
     expect(r.recommendation.totalGpus).toBe(4)
@@ -165,7 +165,7 @@ describe('callGpuSizer', () => {
     const mockFetch = mockFetchOk(EXTERNAL_RESPONSE)
     vi.stubGlobal('fetch', mockFetch)
 
-    await callGpuSizer(VALID_REQUEST)
+    await callRecommend(VALID_REQUEST)
 
     expect(mockFetch.mock.calls[0][0]).toBe('https://aiconfigurator.dev/recommend')
   })
@@ -174,7 +174,7 @@ describe('callGpuSizer', () => {
     const mockFetch = mockFetchOk(EXTERNAL_RESPONSE)
     vi.stubGlobal('fetch', mockFetch)
 
-    await callGpuSizer(VALID_REQUEST)
+    await callRecommend(VALID_REQUEST)
 
     const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body)
     expect(sentBody.model_path).toBe('meta-llama/Llama-3.1-70B-Instruct')
@@ -192,7 +192,7 @@ describe('callGpuSizer', () => {
     vi.stubGlobal('fetch', mockFetch)
 
     const model_config = { hidden_size: 8192, architectures: ['LlamaForCausalLM'] }
-    await callGpuSizer({ ...VALID_REQUEST, model_config })
+    await callRecommend({ ...VALID_REQUEST, model_config })
 
     const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body)
     expect(sentBody.model_config).toEqual(model_config)
@@ -202,7 +202,7 @@ describe('callGpuSizer', () => {
     const mockFetch = mockFetchOk(EXTERNAL_RESPONSE)
     vi.stubGlobal('fetch', mockFetch)
 
-    await callGpuSizer(VALID_REQUEST)
+    await callRecommend(VALID_REQUEST)
 
     const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body)
     expect(sentBody).not.toHaveProperty('model_config')
@@ -211,10 +211,10 @@ describe('callGpuSizer', () => {
   it('returns AIC_NOT_CONFIGURED when API URL is missing', async () => {
     vi.stubEnv('AICONFIGURATOR_GATEWAY_URL', '')
 
-    const result = await callGpuSizer(VALID_REQUEST)
+    const result = await callRecommend(VALID_REQUEST)
 
     expect(result.status).toBe('failed')
-    expect((result as GpuSizerErrorResponse).error.code).toBe('AIC_NOT_CONFIGURED')
+    expect((result as RecommendErrorResponse).error.code).toBe('AIC_NOT_CONFIGURED')
   })
 
   it('returns AIC_TIMEOUT on fetch timeout', async () => {
@@ -222,19 +222,19 @@ describe('callGpuSizer', () => {
     timeoutError.name = 'TimeoutError'
     vi.stubGlobal('fetch', vi.fn().mockRejectedValue(timeoutError))
 
-    const result = await callGpuSizer(VALID_REQUEST)
+    const result = await callRecommend(VALID_REQUEST)
 
     expect(result.status).toBe('failed')
-    expect((result as GpuSizerErrorResponse).error.code).toBe('AIC_TIMEOUT')
+    expect((result as RecommendErrorResponse).error.code).toBe('AIC_TIMEOUT')
   })
 
   it('returns AIC_UNAVAILABLE on network error', async () => {
     vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new TypeError('fetch failed')))
 
-    const result = await callGpuSizer(VALID_REQUEST)
+    const result = await callRecommend(VALID_REQUEST)
 
     expect(result.status).toBe('failed')
-    expect((result as GpuSizerErrorResponse).error.code).toBe('AIC_UNAVAILABLE')
+    expect((result as RecommendErrorResponse).error.code).toBe('AIC_UNAVAILABLE')
   })
 
   it('returns AIC_UNAVAILABLE on 500', async () => {
@@ -244,10 +244,10 @@ describe('callGpuSizer', () => {
       json: () => Promise.resolve({ detail: 'internal error' }),
     }))
 
-    const result = await callGpuSizer(VALID_REQUEST)
+    const result = await callRecommend(VALID_REQUEST)
 
     expect(result.status).toBe('failed')
-    expect((result as GpuSizerErrorResponse).error.code).toBe('AIC_UNAVAILABLE')
+    expect((result as RecommendErrorResponse).error.code).toBe('AIC_UNAVAILABLE')
   })
 
   it('returns AIC_NO_CONFIGURATION on 422', async () => {
@@ -257,10 +257,10 @@ describe('callGpuSizer', () => {
       json: () => Promise.resolve({ detail: 'No configuration meets the specified requirements.' }),
     }))
 
-    const result = await callGpuSizer(VALID_REQUEST)
+    const result = await callRecommend(VALID_REQUEST)
 
     expect(result.status).toBe('failed')
-    expect((result as GpuSizerErrorResponse).error.code).toBe('AIC_NO_CONFIGURATION')
+    expect((result as RecommendErrorResponse).error.code).toBe('AIC_NO_CONFIGURATION')
   })
 
   it('returns AIC_INVALID_RESPONSE on non-JSON response', async () => {
@@ -270,19 +270,19 @@ describe('callGpuSizer', () => {
       json: () => Promise.reject(new Error('invalid json')),
     }))
 
-    const result = await callGpuSizer(VALID_REQUEST)
+    const result = await callRecommend(VALID_REQUEST)
 
     expect(result.status).toBe('failed')
-    expect((result as GpuSizerErrorResponse).error.code).toBe('AIC_INVALID_RESPONSE')
+    expect((result as RecommendErrorResponse).error.code).toBe('AIC_INVALID_RESPONSE')
   })
 
   it('returns AIC_NO_CONFIGURATION when configs array is empty', async () => {
     vi.stubGlobal('fetch', mockFetchOk({ configs: [], chosen_mode: 'agg' }))
 
-    const result = await callGpuSizer(VALID_REQUEST)
+    const result = await callRecommend(VALID_REQUEST)
 
     expect(result.status).toBe('failed')
-    expect((result as GpuSizerErrorResponse).error.code).toBe('AIC_NO_CONFIGURATION')
+    expect((result as RecommendErrorResponse).error.code).toBe('AIC_NO_CONFIGURATION')
   })
 
   it('adds GPU_TOPOLOGY_MISMATCH warning when parallelism does not match GPU count', async () => {
@@ -298,7 +298,7 @@ describe('callGpuSizer', () => {
     }
     vi.stubGlobal('fetch', mockFetchOk(mismatchResponse))
 
-    const result = await callGpuSizer(VALID_REQUEST) as GpuSizerResult
+    const result = await callRecommend(VALID_REQUEST) as RecommendResult
 
     expect(result.status).toBe('completed')
     expect(result.warnings.some(w => w.code === 'GPU_TOPOLOGY_MISMATCH')).toBe(true)
@@ -307,7 +307,7 @@ describe('callGpuSizer', () => {
   it('includes durationMs in metadata', async () => {
     vi.stubGlobal('fetch', mockFetchOk(EXTERNAL_RESPONSE))
 
-    const result = await callGpuSizer(VALID_REQUEST) as GpuSizerResult
+    const result = await callRecommend(VALID_REQUEST) as RecommendResult
 
     expect(result.metadata.durationMs).toBeTypeOf('number')
     expect(result.metadata.durationMs).toBeGreaterThanOrEqual(0)

--- a/lib/api/errors.ts
+++ b/lib/api/errors.ts
@@ -40,19 +40,4 @@ export const ApiErrors = {
 
   INVALID_REQUEST: (message: string) =>
     createApiError('invalid_request', message),
-
-  GPU_SIZER_NOT_CONFIGURED: () =>
-    createApiError('gpu_sizer_not_configured', 'GPU sizing service is not configured'),
-
-  GPU_SIZER_AUTH_FAILED: () =>
-    createApiError('gpu_sizer_auth_failed', 'Authentication with GPU sizing service failed'),
-
-  GPU_SIZER_UNAVAILABLE: (detail?: string) =>
-    createApiError('gpu_sizer_unavailable', detail ?? 'GPU sizing service is unreachable'),
-
-  GPU_SIZER_TIMEOUT: () =>
-    createApiError('gpu_sizer_timeout', 'The GPU sizing engine took longer than expected (90s timeout)'),
-
-  GPU_SIZER_INVALID_RESPONSE: (detail?: string) =>
-    createApiError('gpu_sizer_invalid_response', detail ?? 'GPU sizing service returned an invalid response'),
 }

--- a/lib/api/recommend.ts
+++ b/lib/api/recommend.ts
@@ -1,13 +1,13 @@
-import type { GpuSizerRequest } from './schemas'
+import type { RecommendRequest } from './schemas'
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
-interface GpuSizerWarning {
+interface RecommendWarning {
   code: string
   message: string
 }
 
-export interface GpuSizerResult {
+export interface RecommendResult {
   requestId: string
   status: 'completed'
   recommendation: {
@@ -42,10 +42,10 @@ export interface GpuSizerResult {
     targetTtftMs: number
     durationMs: number
   }
-  warnings: GpuSizerWarning[]
+  warnings: RecommendWarning[]
 }
 
-export interface GpuSizerErrorResponse {
+export interface RecommendErrorResponse {
   requestId: string
   status: 'failed'
   error: {
@@ -54,7 +54,7 @@ export interface GpuSizerErrorResponse {
   }
 }
 
-export type GpuSizerResponse = GpuSizerResult | GpuSizerErrorResponse
+export type RecommendResponse = RecommendResult | RecommendErrorResponse
 
 // ─── Request ID ──────────────────────────────────────────────────────────────
 
@@ -66,9 +66,9 @@ export function generateRequestId(): string {
 
 const DEFAULT_TIMEOUT_SECONDS = 90
 
-export async function callGpuSizer(
-  request: GpuSizerRequest
-): Promise<GpuSizerResponse> {
+export async function callRecommend(
+  request: RecommendRequest
+): Promise<RecommendResponse> {
   const requestId = generateRequestId()
   const startTime = performance.now()
 
@@ -148,7 +148,7 @@ export async function callGpuSizer(
   const dp = (best.dp as number) ?? 1
   const replicasNeeded = (best.replicas_needed as number) ?? 1
 
-  const warnings: GpuSizerWarning[] = []
+  const warnings: RecommendWarning[] = []
   const parallelismProduct = tp * pp * dp
   if (parallelismProduct !== numTotalGpus) {
     warnings.push({
@@ -200,6 +200,6 @@ export async function callGpuSizer(
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
-function makeError(requestId: string, code: string, message: string): GpuSizerErrorResponse {
+function makeError(requestId: string, code: string, message: string): RecommendErrorResponse {
   return { requestId, status: 'failed', error: { code, message } }
 }

--- a/lib/api/schemas.ts
+++ b/lib/api/schemas.ts
@@ -26,9 +26,9 @@ export const ModelCatalogQuerySchema = z.object({
 
 export type ModelCatalogQuery = z.infer<typeof ModelCatalogQuerySchema>
 
-// ═══ GPU SIZER REQUEST SCHEMA ═══
+// ═══ RECOMMEND REQUEST SCHEMA ═══
 
-export const GpuSizerRequestSchema = z.object({
+export const RecommendRequestSchema = z.object({
   model_path: z.string().min(1, 'model_path is required'),
   system: z.string().min(1, 'system is required'),
   backend: z.string().default('vllm'),
@@ -50,7 +50,7 @@ export const GpuSizerRequestSchema = z.object({
   { message: 'Exactly one of target_request_rate or target_concurrency must be provided' }
 )
 
-export type GpuSizerRequest = z.infer<typeof GpuSizerRequestSchema>
+export type RecommendRequest = z.infer<typeof RecommendRequestSchema>
 
 // ═══ KV CACHE CALCULATOR REQUEST SCHEMA ═══
 


### PR DESCRIPTION
## Summary

The Recommend tool's API client and React context still used the legacy **`GpuSizer`** domain token, out of step with its sibling modules (`KvCacheCalc`, `Estimate`) which name the domain after its endpoint. Since this code powers `/api/recommend` and the `app/recommend` tool, this renames the token to **`Recommend`** to match the modern naming used by the tool and the REST API.

## Changes

- `lib/api/gpu-sizer.ts` → `lib/api/recommend.ts` (+ test file)
- `contexts/GpuSizerContext.tsx` → `contexts/RecommendContext.tsx`
- Identifiers renamed:
  - `GpuSizer{Request,RequestSchema,Result,Warning,ErrorResponse,Response}` → `Recommend*`
  - `callGpuSizer` → `callRecommend`
  - `useGpuSizer` → `useRecommend`
  - `GpuSizerProvider` / `GpuSizerContext` / `GpuSizerState` / `GpuSizerParams` → `Recommend*`
- Removed dead `ApiErrors.GPU_SIZER_*` factories (unused — the live error codes are the `AIC_*` family)

## Notes

No behavior change — this is a pure rename. Type-check, lint, and all 29 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Standardized GPU sizing terminology to recommendation terminology across the recommendation experience and API.
  - Recommendation requests continue using the existing validation, processing, loading, error-handling, and result behavior.
  - The recommendation route remains available at `/recommend`.

- **Bug Fixes**
  - Updated recommendation API handling and validation to consistently use recommendation-specific responses and error reporting.

- **Tests**
  - Updated automated coverage for recommendation requests, successful responses, configuration forwarding, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->