### PR TITLE
feat: disaggregated (prefill/decode) serving support

### DIFF
--- a/app/kv-cache/KvCacheCalc.module.css
+++ b/app/kv-cache/KvCacheCalc.module.css
@@ -203,6 +203,52 @@
   grid-template-columns: 1fr 1fr;
   gap: 16px;
 }
+
+/* ---------- serving-mode toggle ---------- */
+.modeToggle {
+  display: inline-flex;
+  border: 1px solid var(--line2);
+  border-radius: 4px;
+  overflow: hidden;
+}
+.modeButton {
+  padding: 7px 18px;
+  border: none;
+  background: #ffffff;
+  color: var(--t2);
+  font-family: var(--sans);
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+}
+.modeButton + .modeButton { border-left: 1px solid var(--line2); }
+.modeButton:hover:not(.modeButtonActive) { background: var(--bg2, #f5f5f5); }
+.modeButtonActive {
+  background: var(--blue);
+  color: #ffffff;
+}
+
+/* ---------- per-phase parallelism label ---------- */
+.phaseFieldsLabel {
+  font-family: var(--mono);
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--t2);
+  margin: 12px 0 6px;
+}
+
+/* ---------- per-pool result block (disagg) ---------- */
+.phaseBlock { margin-bottom: 28px; }
+.phaseTitle {
+  font-family: var(--display, var(--sans));
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--t);
+  margin: 0 0 12px;
+  padding-bottom: 6px;
+  border-bottom: 2px solid var(--line);
+}
+
 @media (max-width: 900px) {
   .advancedRow4 { grid-template-columns: 1fr 1fr; }
 }

--- a/app/kv-cache/KvCacheCalc.tsx
+++ b/app/kv-cache/KvCacheCalc.tsx
@@ -370,7 +370,7 @@ export default function KvCacheCalc() {
               <button
                 type="button"
                 className={`${styles.modeButton} ${servingMode === 'agg' ? styles.modeButtonActive : ''}`}
-                onClick={() => setServingMode('agg')}
+                onClick={() => { setServingMode('agg'); setResults([]); }}
                 aria-pressed={servingMode === 'agg'}
               >
                 Aggregated
@@ -378,7 +378,7 @@ export default function KvCacheCalc() {
               <button
                 type="button"
                 className={`${styles.modeButton} ${servingMode === 'disagg' ? styles.modeButtonActive : ''}`}
-                onClick={() => setServingMode('disagg')}
+                onClick={() => { setServingMode('disagg'); setResults([]); }}
                 aria-pressed={servingMode === 'disagg'}
               >
                 Disaggregated

--- a/app/kv-cache/KvCacheCalc.tsx
+++ b/app/kv-cache/KvCacheCalc.tsx
@@ -25,6 +25,41 @@ const BREAKDOWN_COLORS: Record<string, string> = {
   comm: '#009596',
 }
 
+/** Parallelism inputs for one disagg pool (string-backed, parsed at calc time). */
+interface PhaseParallelInput {
+  tp: string
+  pp: string
+  moeTp: string
+  moeEp: string
+}
+
+/** A computed KV-cache result tagged with its pool label ('' for agg). */
+interface PhaseResult {
+  label: string
+  result: KvCacheCalcResult
+}
+
+/** Parallelism fields sent to /api/memory for one pool. */
+interface PhaseParallel {
+  tp: number
+  pp: number
+  moeTp: number
+  moeEp: number
+}
+
+function parsePhaseParallel(p: PhaseParallelInput): PhaseParallel {
+  return {
+    tp: Math.max(1, parseInt(p.tp, 10) || 1),
+    pp: Math.max(1, parseInt(p.pp, 10) || 1),
+    moeTp: parseInt(p.moeTp, 10) || 0,
+    moeEp: parseInt(p.moeEp, 10) || 0,
+  }
+}
+
+function invalidPhaseParallel(p: PhaseParallelInput): boolean {
+  return p.tp === '' || parseInt(p.tp, 10) < 1 || p.pp === '' || parseInt(p.pp, 10) < 1
+}
+
 export default function KvCacheCalc() {
   const { hydrated, hfToken, defaultModel: settingsDefaultModel, inferenceBackend, backendVersion: settingsBackendVersion } = useSettings()
   const { modelOptions: aicModels, gpuOptions: aicGpus, isLoading: catalogLoading } = useAicCatalog()
@@ -53,16 +88,19 @@ export default function KvCacheCalc() {
   const [ppSize, setPpSize] = React.useState(1)
   const [moeTpSize, setMoeTpSize] = React.useState('')
   const [moeEpSize, setMoeEpSize] = React.useState('')
+  // Disagg: prefill and decode pools have independent parallelism.
+  const [servingMode, setServingMode] = React.useState<'agg' | 'disagg'>('agg')
+  const [prefillPar, setPrefillPar] = React.useState<PhaseParallelInput>({ tp: '1', pp: '1', moeTp: '', moeEp: '' })
+  const [decodePar, setDecodePar] = React.useState<PhaseParallelInput>({ tp: '1', pp: '1', moeTp: '', moeEp: '' })
   const [memFractionKind, setMemFractionKind] = React.useState('of_total')
   const [memFractionValue, setMemFractionValue] = React.useState(1.0)
   const [advancedOpen, setAdvancedOpen] = React.useState(false)
   const [loading, setLoading] = React.useState(false)
-  const [result, setResult] = React.useState<KvCacheCalcResult | null>(null)
+  const [results, setResults] = React.useState<PhaseResult[]>([])
   const [error, setError] = React.useState<string | null>(null)
-  const [flipped, setFlipped] = React.useState<Record<string, boolean>>({})
   const [debugOpen, setDebugOpen] = React.useState(false)
-  const [debugRequest, setDebugRequest] = React.useState<Record<string, unknown> | null>(null)
-  const [debugResponse, setDebugResponse] = React.useState<Record<string, unknown> | null>(null)
+  const [debugRequest, setDebugRequest] = React.useState<unknown>(null)
+  const [debugResponse, setDebugResponse] = React.useState<unknown>(null)
   const [debugStatus, setDebugStatus] = React.useState<number | null>(null)
   const [debugDuration, setDebugDuration] = React.useState<number | null>(null)
 
@@ -77,6 +115,9 @@ export default function KvCacheCalc() {
   const invalidTpSize = tpSizeInput === '' || parseInt(tpSizeInput, 10) < 1;
   const invalidPpSize = ppSizeInput === '' || parseInt(ppSizeInput, 10) < 1;
   const invalidMemFractionValue = memFractionValueInput === '' || !Number.isFinite(Number(memFractionValueInput)) || Number(memFractionValueInput) < 0 || Number(memFractionValueInput) > 1;
+  const invalidParallelism = servingMode === 'disagg'
+    ? invalidPhaseParallel(prefillPar) || invalidPhaseParallel(decodePar)
+    : invalidTpSize || invalidPpSize;
 
   const handleMaxNumTokensChange = (raw: string) => {
     const digits = raw.replace(/[^0-9]/g, '');
@@ -140,29 +181,42 @@ export default function KvCacheCalc() {
     : catalogLoading ? 'fetching'
     : model ? 'idle' : 'idle'
 
-  async function handleCalculate() {
-    setLoading(true)
-    setError(null)
-    setResult(null)
-
-    const requestBody: Record<string, unknown> = {
+  function buildRequestBody(par: PhaseParallel): Record<string, unknown> {
+    const body: Record<string, unknown> = {
       model_path: model,
       system,
       backend,
       max_num_tokens: maxNumTokens,
       max_batch_size: maxBatchSize,
-      tp_size: tpSize,
-      pp_size: ppSize,
+      tp_size: par.tp,
+      pp_size: par.pp,
       memory_fraction_kind: memFractionKind,
       memory_fraction_value: memFractionValue,
     }
-    if (backendVersion.trim()) requestBody.backend_version = backendVersion.trim()
-    if (needsHfConfig(model, aicModels) && hfConfig) requestBody.model_config = hfConfig
-    const moeTp = parseInt(moeTpSize, 10)
-    if (!isNaN(moeTp) && moeTp > 0) requestBody.moe_tp_size = moeTp
-    const moeEp = parseInt(moeEpSize, 10)
-    if (!isNaN(moeEp) && moeEp > 0) requestBody.moe_ep_size = moeEp
-    setDebugRequest(requestBody)
+    if (backendVersion.trim()) body.backend_version = backendVersion.trim()
+    if (needsHfConfig(model, aicModels) && hfConfig) body.model_config = hfConfig
+    if (par.moeTp > 0) body.moe_tp_size = par.moeTp
+    if (par.moeEp > 0) body.moe_ep_size = par.moeEp
+    return body
+  }
+
+  async function handleCalculate() {
+    setLoading(true)
+    setError(null)
+    setResults([])
+
+    // One request per pool. Agg is a single unlabelled pool; disagg fans out to
+    // prefill + decode, each with its own parallelism, against the same /memory
+    // endpoint (which already takes tp/pp/moe dims).
+    const phases: { label: string; par: PhaseParallel }[] = servingMode === 'disagg'
+      ? [
+          { label: 'Prefill', par: parsePhaseParallel(prefillPar) },
+          { label: 'Decode', par: parsePhaseParallel(decodePar) },
+        ]
+      : [{ label: '', par: { tp: tpSize, pp: ppSize, moeTp: parseInt(moeTpSize, 10) || 0, moeEp: parseInt(moeEpSize, 10) || 0 } }]
+
+    const requestBodies = phases.map(ph => ({ label: ph.label, body: buildRequestBody(ph.par) }))
+    setDebugRequest(servingMode === 'disagg' ? requestBodies : requestBodies[0].body)
     setDebugResponse(null)
     setDebugStatus(null)
     setDebugDuration(null)
@@ -170,23 +224,29 @@ export default function KvCacheCalc() {
     const t0 = performance.now()
 
     try {
-      const res = await fetch('/api/memory', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(requestBody),
-      })
+      const responses = await Promise.all(
+        requestBodies.map(async ({ label, body }) => {
+          const res = await fetch('/api/memory', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(body),
+          })
+          const data = await res.json()
+          return { label, status: res.status, data }
+        }),
+      )
 
-      const data = await res.json()
-      setDebugResponse(data)
-      setDebugStatus(res.status)
+      setDebugResponse(servingMode === 'disagg' ? responses.map(r => r.data) : responses[0].data)
+      setDebugStatus(responses[responses.length - 1].status)
       setDebugDuration(Math.round(performance.now() - t0))
 
-      if (data.status === 'failed') {
-        setError(data.error?.message ?? 'An unexpected error occurred')
+      const failed = responses.find(r => r.data?.status === 'failed')
+      if (failed) {
+        setError(failed.data.error?.message ?? 'An unexpected error occurred')
         return
       }
 
-      setResult(data as KvCacheCalcResult)
+      setResults(responses.map(r => ({ label: r.label, result: r.data as KvCacheCalcResult })))
     } catch {
       setDebugDuration(Math.round(performance.now() - t0))
       setError('Failed to connect to the server. Please try again.')
@@ -194,15 +254,6 @@ export default function KvCacheCalc() {
       setLoading(false)
     }
   }
-
-  function toggleFlip(id: string) {
-    setFlipped(prev => ({ ...prev, [id]: !prev[id] }))
-  }
-
-  const animKv = useCountUp(result?.kvCache.totalBytes ?? 0, 800)
-  const animPerToken = useCountUp(result?.kvCache.perTokenBytes ?? 0, 800)
-  const animTokens = useCountUp(result?.kvCache.totalTokens ?? 0, 800)
-  const animGpuCap = useCountUp(result?.gpuCapacity.totalBytes ?? 0, 800)
 
   return (
     <div className={styles.page}>
@@ -237,7 +288,7 @@ export default function KvCacheCalc() {
             type="button"
             className={styles.calcBtn}
             onClick={handleCalculate} 
-            disabled={loading || !model.trim() || invalidMaxNumTokens || invalidMaxBatchSize || invalidTpSize || invalidPpSize || invalidMemFractionValue}
+            disabled={loading || !model.trim() || invalidMaxNumTokens || invalidMaxBatchSize || invalidParallelism || invalidMemFractionValue}
           >
             {loading ? 'Calculating…' : 'Calculate'}
           </button>
@@ -254,7 +305,10 @@ export default function KvCacheCalc() {
           Advanced settings
           {!advancedOpen && (
             <span className={styles.advancedSummary}>
-              {backend}{backendVersion ? ` v${backendVersion}` : ''} · tokens: {maxNumTokens.toLocaleString()} · batch: {maxBatchSize} · TP {tpSize}{ppSize > 1 ? ` · PP ${ppSize}` : ''}{moeTpSize ? ` · MoE TP ${moeTpSize}` : ''}
+              {backend}{backendVersion ? ` v${backendVersion}` : ''} · tokens: {maxNumTokens.toLocaleString()} · batch: {maxBatchSize}
+              {servingMode === 'disagg'
+                ? ` · disagg · P: TP ${prefillPar.tp}/PP ${prefillPar.pp} · D: TP ${decodePar.tp}/PP ${decodePar.pp}`
+                : ` · TP ${tpSize}${ppSize > 1 ? ` · PP ${ppSize}` : ''}${moeTpSize ? ` · MoE TP ${moeTpSize}` : ''}`}
             </span>
           )}
         </button>
@@ -310,54 +364,82 @@ export default function KvCacheCalc() {
               </div>
             </div>
 
+            {/* Serving mode */}
+            <div className={styles.advancedSectionLabel}>Serving mode</div>
+            <div className={styles.modeToggle}>
+              <button
+                type="button"
+                className={`${styles.modeButton} ${servingMode === 'agg' ? styles.modeButtonActive : ''}`}
+                onClick={() => setServingMode('agg')}
+                aria-pressed={servingMode === 'agg'}
+              >
+                Aggregated
+              </button>
+              <button
+                type="button"
+                className={`${styles.modeButton} ${servingMode === 'disagg' ? styles.modeButtonActive : ''}`}
+                onClick={() => setServingMode('disagg')}
+                aria-pressed={servingMode === 'disagg'}
+              >
+                Disaggregated
+              </button>
+            </div>
+
             {/* Parallelism */}
             <div className={styles.advancedSectionLabel}>Parallelism</div>
-            <div className={styles.advancedRow4}>
-              <div className={styles.field}>
-                <label htmlFor="kv-tp" className={styles.fieldLabel}>TP size</label>
-                <input
-                  type="number"
-                  id="kv-tp"
-                  value={tpSizeInput}
-                  onChange={e => handleTpSizeChange(e.target.value)}
-                  min={1}
-                  className={invalidTpSize ? styles.paramInputInvalid : styles.numberInput}
-                />
+            {servingMode === 'agg' ? (
+              <div className={styles.advancedRow4}>
+                <div className={styles.field}>
+                  <label htmlFor="kv-tp" className={styles.fieldLabel}>TP size</label>
+                  <input
+                    type="number"
+                    id="kv-tp"
+                    value={tpSizeInput}
+                    onChange={e => handleTpSizeChange(e.target.value)}
+                    min={1}
+                    className={invalidTpSize ? styles.paramInputInvalid : styles.numberInput}
+                  />
+                </div>
+                <div className={styles.field}>
+                  <label htmlFor="kv-pp" className={styles.fieldLabel}>PP size</label>
+                  <input
+                    type="number"
+                    id="kv-pp"
+                    value={ppSizeInput}
+                    onChange={e => handlePpSizeChange(e.target.value)}
+                    min={1}
+                    className={invalidPpSize ? styles.paramInputInvalid : styles.numberInput}
+                  />
+                </div>
+                <div className={styles.field}>
+                  <label htmlFor="kv-moe-tp" className={styles.fieldLabel}>MoE TP size</label>
+                  <input
+                    type="text"
+                    id="kv-moe-tp"
+                    value={moeTpSize}
+                    onChange={e => setMoeTpSize(e.target.value.replace(/[^0-9]/g, ''))}
+                    placeholder="auto"
+                    className={styles.numberInput}
+                  />
+                </div>
+                <div className={styles.field}>
+                  <label htmlFor="kv-moe-ep" className={styles.fieldLabel}>MoE EP size</label>
+                  <input
+                    type="text"
+                    id="kv-moe-ep"
+                    value={moeEpSize}
+                    onChange={e => setMoeEpSize(e.target.value.replace(/[^0-9]/g, ''))}
+                    placeholder="auto"
+                    className={styles.numberInput}
+                  />
+                </div>
               </div>
-              <div className={styles.field}>
-                <label htmlFor="kv-pp" className={styles.fieldLabel}>PP size</label>
-                <input
-                  type="number"
-                  id="kv-pp"
-                  value={ppSizeInput}
-                  onChange={e => handlePpSizeChange(e.target.value)}
-                  min={1}
-                  className={invalidPpSize ? styles.paramInputInvalid : styles.numberInput}
-                />
-              </div>
-              <div className={styles.field}>
-                <label htmlFor="kv-moe-tp" className={styles.fieldLabel}>MoE TP size</label>
-                <input
-                  type="text"
-                  id="kv-moe-tp"
-                  value={moeTpSize}
-                  onChange={e => setMoeTpSize(e.target.value.replace(/[^0-9]/g, ''))}
-                  placeholder="auto"
-                  className={styles.numberInput}
-                />
-              </div>
-              <div className={styles.field}>
-                <label htmlFor="kv-moe-ep" className={styles.fieldLabel}>MoE EP size</label>
-                <input
-                  type="text"
-                  id="kv-moe-ep"
-                  value={moeEpSize}
-                  onChange={e => setMoeEpSize(e.target.value.replace(/[^0-9]/g, ''))}
-                  placeholder="auto"
-                  className={styles.numberInput}
-                />
-              </div>
-            </div>
+            ) : (
+              <>
+                <PhaseParallelFields title="Prefill pool" par={prefillPar} onChange={setPrefillPar} idPrefix="kv-p" />
+                <PhaseParallelFields title="Decode pool" par={decodePar} onChange={setDecodePar} idPrefix="kv-d" />
+              </>
+            )}
 
             {/* Memory */}
             <div className={styles.advancedSectionLabel}>Memory</div>
@@ -417,111 +499,19 @@ export default function KvCacheCalc() {
       )}
 
       {/* Placeholder */}
-      {!loading && !result && !error}
+      {!loading && results.length === 0 && !error}
 
-      {/* Results */}
-      {result && !loading && (
+      {/* Results — one section per pool (agg = single unlabelled pool) */}
+      {results.length > 0 && !loading && (
         <>
-          {/* Tiles */}
-          <div className={styles.tilesGrid}>
-            {/* Total KV cache */}
-            <TileCard
-              id="total"
-              dark
-              label="Available for KV cache / GPU"
-              value={formatBytes(animKv)}
-              sub={`${result.kvCache.totalTokens.toLocaleString()} tokens capacity`}
-              flipped={flipped.total ?? false}
-              onFlip={() => toggleFlip('total')}
-              backContent={
-                <>
-                  <div className={styles.backTitle}>KV cache / GPU detail</div>
-                  <BackRow label="Raw bytes" value={result.kvCache.totalBytes.toLocaleString()} dark />
-                  <BackRow label="Total tokens" value={result.kvCache.totalTokens.toLocaleString()} dark />
-                  <BackRow label="Per token" value={`${result.kvCache.perTokenBytes.toLocaleString()} B`} dark />
-                  <BackRow label="Source" value={result.metadata.source} dark />
-                </>
-              }
-            />
-
-            {/* Per token */}
-            <TileCard
-              id="pertoken"
-              label="Per token"
-              value={formatBytes(animPerToken)}
-              sub="KV cache memory per token"
-              flipped={flipped.pertoken ?? false}
-              onFlip={() => toggleFlip('pertoken')}
-              backContent={
-                <>
-                  <div className={styles.backTitle}>Per-token detail</div>
-                  <BackRow label="Bytes/token" value={result.kvCache.perTokenBytes.toLocaleString()} />
-                  <BackRow label="Total tokens" value={result.kvCache.totalTokens.toLocaleString()} />
-                </>
-              }
-            />
-
-            {/* Token capacity */}
-            <TileCard
-              id="tokens"
-              label="Token capacity"
-              value={animTokens.toLocaleString()}
-              sub="Max tokens in KV cache"
-              flipped={flipped.tokens ?? false}
-              onFlip={() => toggleFlip('tokens')}
-              backContent={
-                <>
-                  <div className={styles.backTitle}>Capacity detail</div>
-                  <BackRow label="Total tokens" value={result.kvCache.totalTokens.toLocaleString()} />
-                  <BackRow label="KV size" value={formatBytes(result.kvCache.totalBytes)} />
-                  <BackRow label="Per token" value={`${result.kvCache.perTokenBytes.toLocaleString()} B`} />
-                </>
-              }
-            />
-
-            {/* GPU capacity */}
-            <TileCard
-              id="gpu"
-              label="GPU memory"
-              value={formatBytes(animGpuCap)}
-              sub={`${result.metadata.system} total capacity`}
-              flipped={flipped.gpu ?? false}
-              onFlip={() => toggleFlip('gpu')}
-              backContent={
-                <>
-                  <div className={styles.backTitle}>GPU memory detail</div>
-                  <BackRow label="Total GPU" value={formatBytes(result.gpuCapacity.totalBytes)} />
-                  <BackRow label="KV cache" value={formatBytes(result.kvCache.totalBytes)} />
-                  <BackRow label="KV % of GPU" value={`${((result.kvCache.totalBytes / result.gpuCapacity.totalBytes) * 100).toFixed(1)}%`} />
-                </>
-              }
-            />
-          </div>
-
-          {/* Memory breakdown bar */}
-          <MemoryBreakdownSection result={result} />
-
-          {/* Metadata */}
-          <div className={styles.configSection}>
-            <div className={styles.configTitle}>Request details</div>
-            <div className={styles.configGrid}>
-              <ConfigItem label="Model" value={result.metadata.modelPath} />
-              <ConfigItem label="Backend" value={result.metadata.backendVersion ? `${result.metadata.backend} v${result.metadata.backendVersion}` : result.metadata.backend} />
-              <ConfigItem label="GPU system" value={result.metadata.system} />
-              <ConfigItem label="Max tokens" value={result.metadata.maxNumTokens.toLocaleString()} />
-              <ConfigItem label="Batch size" value={result.metadata.maxBatchSize.toLocaleString()} />
-              <ConfigItem label="TP / PP" value={`${result.metadata.tpSize} / ${result.metadata.ppSize}`} />
-              {result.metadata.moeTpSize != null && <ConfigItem label="MoE TP" value={String(result.metadata.moeTpSize)} />}
-              {result.metadata.moeEpSize != null && <ConfigItem label="MoE EP" value={String(result.metadata.moeEpSize)} />}
-              <ConfigItem label="Mem fraction" value={`${result.metadata.memoryFractionValue} (${result.metadata.memoryFractionKind})`} />
-              <ConfigItem label="Source" value={result.metadata.source} />
-            </div>
-          </div>
+          {results.map(({ label, result }) => (
+            <PhaseResults key={label || 'agg'} label={label} result={result} />
+          ))}
         </>
       )}
 
       {/* Debug panel */}
-      {(debugRequest || debugResponse) && (
+      {(debugRequest != null || debugResponse != null) && (
         <div className={styles.debugSection}>
           <button
             type="button"
@@ -566,6 +556,163 @@ export default function KvCacheCalc() {
 }
 
 // ─── Sub-components ─────────────────────────────────────────────────────────
+
+/** Four inputs (TP/PP/MoE TP/MoE EP) for one disagg pool. */
+function PhaseParallelFields({ title, par, onChange, idPrefix }: {
+  title: string
+  par: PhaseParallelInput
+  onChange: (p: PhaseParallelInput) => void
+  idPrefix: string
+}) {
+  const digits = (v: string) => v.replace(/[^0-9]/g, '')
+  const invalidTp = par.tp === '' || parseInt(par.tp, 10) < 1
+  const invalidPp = par.pp === '' || parseInt(par.pp, 10) < 1
+  return (
+    <>
+      <div className={styles.phaseFieldsLabel}>{title}</div>
+      <div className={styles.advancedRow4}>
+        <div className={styles.field}>
+          <label htmlFor={`${idPrefix}-tp`} className={styles.fieldLabel}>TP size</label>
+          <input
+            type="number" id={`${idPrefix}-tp`} value={par.tp} min={1}
+            onChange={e => onChange({ ...par, tp: digits(e.target.value) })}
+            className={invalidTp ? styles.paramInputInvalid : styles.numberInput}
+          />
+        </div>
+        <div className={styles.field}>
+          <label htmlFor={`${idPrefix}-pp`} className={styles.fieldLabel}>PP size</label>
+          <input
+            type="number" id={`${idPrefix}-pp`} value={par.pp} min={1}
+            onChange={e => onChange({ ...par, pp: digits(e.target.value) })}
+            className={invalidPp ? styles.paramInputInvalid : styles.numberInput}
+          />
+        </div>
+        <div className={styles.field}>
+          <label htmlFor={`${idPrefix}-moe-tp`} className={styles.fieldLabel}>MoE TP size</label>
+          <input
+            type="text" id={`${idPrefix}-moe-tp`} value={par.moeTp} placeholder="auto"
+            onChange={e => onChange({ ...par, moeTp: digits(e.target.value) })}
+            className={styles.numberInput}
+          />
+        </div>
+        <div className={styles.field}>
+          <label htmlFor={`${idPrefix}-moe-ep`} className={styles.fieldLabel}>MoE EP size</label>
+          <input
+            type="text" id={`${idPrefix}-moe-ep`} value={par.moeEp} placeholder="auto"
+            onChange={e => onChange({ ...par, moeEp: digits(e.target.value) })}
+            className={styles.numberInput}
+          />
+        </div>
+      </div>
+    </>
+  )
+}
+
+/** Full result rendering for one pool: tiles + memory breakdown + request detail. */
+function PhaseResults({ label, result }: PhaseResult) {
+  const [flipped, setFlipped] = React.useState<Record<string, boolean>>({})
+  const toggleFlip = (id: string) => setFlipped(prev => ({ ...prev, [id]: !prev[id] }))
+
+  const animKv = useCountUp(result.kvCache.totalBytes, 800)
+  const animPerToken = useCountUp(result.kvCache.perTokenBytes, 800)
+  const animTokens = useCountUp(result.kvCache.totalTokens, 800)
+  const animGpuCap = useCountUp(result.gpuCapacity.totalBytes, 800)
+
+  return (
+    <div className={styles.phaseBlock}>
+      {label && <div className={styles.phaseTitle}>{label}</div>}
+
+      <div className={styles.tilesGrid}>
+        <TileCard
+          id="total"
+          dark
+          label="Available for KV cache / GPU"
+          value={formatBytes(animKv)}
+          sub={`${result.kvCache.totalTokens.toLocaleString()} tokens capacity`}
+          flipped={flipped.total ?? false}
+          onFlip={() => toggleFlip('total')}
+          backContent={
+            <>
+              <div className={styles.backTitle}>KV cache / GPU detail</div>
+              <BackRow label="Raw bytes" value={result.kvCache.totalBytes.toLocaleString()} dark />
+              <BackRow label="Total tokens" value={result.kvCache.totalTokens.toLocaleString()} dark />
+              <BackRow label="Per token" value={`${result.kvCache.perTokenBytes.toLocaleString()} B`} dark />
+              <BackRow label="Source" value={result.metadata.source} dark />
+            </>
+          }
+        />
+
+        <TileCard
+          id="pertoken"
+          label="Per token"
+          value={formatBytes(animPerToken)}
+          sub="KV cache memory per token"
+          flipped={flipped.pertoken ?? false}
+          onFlip={() => toggleFlip('pertoken')}
+          backContent={
+            <>
+              <div className={styles.backTitle}>Per-token detail</div>
+              <BackRow label="Bytes/token" value={result.kvCache.perTokenBytes.toLocaleString()} />
+              <BackRow label="Total tokens" value={result.kvCache.totalTokens.toLocaleString()} />
+            </>
+          }
+        />
+
+        <TileCard
+          id="tokens"
+          label="Token capacity"
+          value={animTokens.toLocaleString()}
+          sub="Max tokens in KV cache"
+          flipped={flipped.tokens ?? false}
+          onFlip={() => toggleFlip('tokens')}
+          backContent={
+            <>
+              <div className={styles.backTitle}>Capacity detail</div>
+              <BackRow label="Total tokens" value={result.kvCache.totalTokens.toLocaleString()} />
+              <BackRow label="KV size" value={formatBytes(result.kvCache.totalBytes)} />
+              <BackRow label="Per token" value={`${result.kvCache.perTokenBytes.toLocaleString()} B`} />
+            </>
+          }
+        />
+
+        <TileCard
+          id="gpu"
+          label="GPU memory"
+          value={formatBytes(animGpuCap)}
+          sub={`${result.metadata.system} total capacity`}
+          flipped={flipped.gpu ?? false}
+          onFlip={() => toggleFlip('gpu')}
+          backContent={
+            <>
+              <div className={styles.backTitle}>GPU memory detail</div>
+              <BackRow label="Total GPU" value={formatBytes(result.gpuCapacity.totalBytes)} />
+              <BackRow label="KV cache" value={formatBytes(result.kvCache.totalBytes)} />
+              <BackRow label="KV % of GPU" value={`${((result.kvCache.totalBytes / result.gpuCapacity.totalBytes) * 100).toFixed(1)}%`} />
+            </>
+          }
+        />
+      </div>
+
+      <MemoryBreakdownSection result={result} />
+
+      <div className={styles.configSection}>
+        <div className={styles.configTitle}>Request details{label ? ` — ${label}` : ''}</div>
+        <div className={styles.configGrid}>
+          <ConfigItem label="Model" value={result.metadata.modelPath} />
+          <ConfigItem label="Backend" value={result.metadata.backendVersion ? `${result.metadata.backend} v${result.metadata.backendVersion}` : result.metadata.backend} />
+          <ConfigItem label="GPU system" value={result.metadata.system} />
+          <ConfigItem label="Max tokens" value={result.metadata.maxNumTokens.toLocaleString()} />
+          <ConfigItem label="Batch size" value={result.metadata.maxBatchSize.toLocaleString()} />
+          <ConfigItem label="TP / PP" value={`${result.metadata.tpSize} / ${result.metadata.ppSize}`} />
+          {result.metadata.moeTpSize != null && <ConfigItem label="MoE TP" value={String(result.metadata.moeTpSize)} />}
+          {result.metadata.moeEpSize != null && <ConfigItem label="MoE EP" value={String(result.metadata.moeEpSize)} />}
+          <ConfigItem label="Mem fraction" value={`${result.metadata.memoryFractionValue} (${result.metadata.memoryFractionKind})`} />
+          <ConfigItem label="Source" value={result.metadata.source} />
+        </div>
+      </div>
+    </div>
+  )
+}
 
 interface TileCardProps {
   id: string

--- a/app/performance/PerformanceEstimate.tsx
+++ b/app/performance/PerformanceEstimate.tsx
@@ -38,7 +38,7 @@ import { useSettings } from '@/contexts/SettingsContext';
 import { useCostings, resolveCloudRate } from '@/lib/hooks/useCostings';
 import { getAppConfig } from '@/lib/app-config';
 import { DEFAULT_WORKLOAD, type WorkloadPreset } from '@/lib/workload-presets';
-import type { InferenceConfigResult } from '@/lib/gpu-math/inference-config';
+import type { EstimatePhase, InferenceConfigResult } from '@/lib/gpu-math/inference-config';
 import Link from 'next/link';
 import { HOURS_PER_MONTH, AMORT_MONTHS_3YR, AMORT_MONTHS_5YR } from '@/lib/utils/format';
 
@@ -702,7 +702,7 @@ export default function QuickEstimate() {
     if (isDisagg) {
       // A single vllm serve can't express disagg; emit one command per pool and
       // note the KV-transfer connector needed to wire prefill -> decode.
-      const poolCmd = (role: string, ph: typeof disagg.prefill) => {
+      const poolCmd = (role: string, ph: EstimatePhase) => {
         const ppFlag = ph.pp_size > 1 ? ` \\\n  --pipeline-parallel-size ${ph.pp_size}` : '';
         return `# ${role} pool — ${ph.workers} worker(s), TP${ph.tp_size}${ph.pp_size > 1 ? ` PP${ph.pp_size}` : ''}, batch ${ph.batch_size}\n` +
           `vllm serve ${model} \\\n` +

--- a/app/performance/PerformanceEstimate.tsx
+++ b/app/performance/PerformanceEstimate.tsx
@@ -684,10 +684,6 @@ export default function QuickEstimate() {
   const handleCopyCLICommand = async () => {
     if (!testResult) return;
 
-    const ppFlag = testResult.parallelism_strategy.pp_size > 1
-      ? ` \\\n  --pipeline-parallel-size ${testResult.parallelism_strategy.pp_size}`
-      : '';
-
     // Only FP16/FP8 are valid --dtype values; quantized modes use --quantization
     const dtypeValue = testWeightPrecision === 'FP16' ? 'float16' :
                        testWeightPrecision === 'FP8' ? 'fp8' : 'auto';
@@ -702,13 +698,37 @@ export default function QuickEstimate() {
       ? ` \\\n  --quantization ${quantValue}`
       : '';
 
-    const cliCommand = `vllm serve ${model} \\
+    let cliCommand: string;
+    if (isDisagg) {
+      // A single vllm serve can't express disagg; emit one command per pool and
+      // note the KV-transfer connector needed to wire prefill -> decode.
+      const poolCmd = (role: string, ph: typeof disagg.prefill) => {
+        const ppFlag = ph.pp_size > 1 ? ` \\\n  --pipeline-parallel-size ${ph.pp_size}` : '';
+        return `# ${role} pool — ${ph.workers} worker(s), TP${ph.tp_size}${ph.pp_size > 1 ? ` PP${ph.pp_size}` : ''}, batch ${ph.batch_size}\n` +
+          `vllm serve ${model} \\\n` +
+          `  --tensor-parallel-size ${ph.tp_size}${ppFlag} \\\n` +
+          `  --gpu-memory-utilization 0.90 \\\n` +
+          `  --dtype ${dtypeValue}${quantFlag} \\\n` +
+          `  --kv-cache-dtype ${testKVCachePrecision.toLowerCase()}`;
+      };
+      cliCommand =
+        `# Disaggregated serving: run the prefill and decode pools separately and\n` +
+        `# connect them with a KV-transfer connector (e.g. LMCache / NIXL / Dynamo).\n` +
+        `# Scale each pool to the worker count shown.\n\n` +
+        `${poolCmd('Prefill', disagg.prefill)}\n\n` +
+        `${poolCmd('Decode', disagg.decode)}`;
+    } else {
+      const ppFlag = testResult.parallelism_strategy.pp_size > 1
+        ? ` \\\n  --pipeline-parallel-size ${testResult.parallelism_strategy.pp_size}`
+        : '';
+      cliCommand = `vllm serve ${model} \\
   --tensor-parallel-size ${testResult.memory_analysis.tp_size}${ppFlag} \\
   --max-model-len auto \\
   --gpu-memory-utilization 0.90 \\
   --dtype ${dtypeValue}${quantFlag} \\
   --kv-cache-dtype ${testKVCachePrecision.toLowerCase()} \\
   --max-num-seqs ${testResult.vllm_config?.max_num_seqs || 256}${testResult.vllm_config?.enable_chunked_prefill ? ' \\\n  --enable-chunked-prefill' : ''}`;
+    }
 
     try {
       await navigator.clipboard.writeText(cliCommand);

--- a/app/performance/PerformanceEstimate.tsx
+++ b/app/performance/PerformanceEstimate.tsx
@@ -46,6 +46,50 @@ function modelSuggestions(): string {
   return getAppConfig().suggestedModelNames.join(', ');
 }
 
+/** String-backed parallelism inputs for one disagg pool (prefill/decode). */
+interface PerfPhaseInput {
+  tp: string
+  pp: string
+  workers: string
+  batch: string
+}
+
+function parsePerfPhase(p: PerfPhaseInput) {
+  const n = (v: string, min = 1) => Math.max(min, parseInt(v, 10) || min);
+  return { tp: n(p.tp), pp: n(p.pp), workers: n(p.workers), batch: n(p.batch) };
+}
+
+/** Four inputs (TP/PP/Workers/Batch) for one disagg pool. */
+function PerfPhaseFields({ title, cfg, onChange }: {
+  title: string;
+  cfg: PerfPhaseInput;
+  onChange: (c: PerfPhaseInput) => void;
+}) {
+  const digits = (v: string) => v.replace(/[^0-9]/g, '');
+  const field = (label: string, key: keyof PerfPhaseInput) => (
+    <div className={styles.accField}>
+      <label className={styles.accFieldLabel}>{label}</label>
+      <TextInput
+        type="number"
+        value={cfg[key]}
+        aria-label={`${title} ${label}`}
+        onChange={(_, v) => onChange({ ...cfg, [key]: digits(v) })}
+      />
+    </div>
+  );
+  return (
+    <div>
+      <div style={{ fontSize: '13px', fontWeight: 600, fontFamily: 'var(--mono)', color: '#3c3f42', marginBottom: 8 }}>{title}</div>
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr 1fr', gap: 12 }}>
+        {field('TP', 'tp')}
+        {field('PP', 'pp')}
+        {field('Workers', 'workers')}
+        {field('Batch', 'batch')}
+      </div>
+    </div>
+  );
+}
+
 
 const QUICK_ESTIMATE_TOUR: TourStep[] = [
   {
@@ -167,7 +211,12 @@ export default function QuickEstimate() {
   const [testKVCachePrecision, setTestKVCachePrecision] = React.useState<'FP16' | 'FP8' | 'NVFP4'>('FP16');
   const [testMoeQuantMode, setTestMoeQuantMode] = React.useState<'w4a16_mxfp4' | 'w4a8_mxfp4_mxfp8' | 'w4a16_mxfp4_cutlass' | 'w4a8_mxfp4_mxfp8_trtllm'>('w4a16_mxfp4');
   const [testPpSize, setTestPpSize] = React.useState(1);
-  
+
+  // Disagg: prefill and decode pools with independent parallelism / batch.
+  const [servingMode, setServingMode] = React.useState<'agg' | 'disagg'>('agg');
+  const [prefillCfg, setPrefillCfg] = React.useState<PerfPhaseInput>({ tp: '1', pp: '1', workers: '1', batch: '1' });
+  const [decodeCfg, setDecodeCfg] = React.useState<PerfPhaseInput>({ tp: '1', pp: '1', workers: '1', batch: '64' });
+
   const [islInput, setIslInput] = React.useState('2048');
   const [oslInput, setOslInput] = React.useState('128');
   const [concurrentUsersInput, setConcurrentUsersInput] = React.useState('1');
@@ -330,6 +379,11 @@ export default function QuickEstimate() {
                           testWeightPrecision === 'NVFP4' ? 'nvfp4' : null,
           moe_quant_mode: isMoe ? testMoeQuantMode : undefined,
           ...(isMoe && { moe_ep_size: testTpSize }),
+          ...(servingMode === 'disagg' && {
+            mode: 'disagg' as const,
+            prefill: parsePerfPhase(prefillCfg),
+            decode: parsePerfPhase(decodeCfg),
+          }),
         });
         if (!cancelled) {
           setTestResult(result);
@@ -428,10 +482,17 @@ export default function QuickEstimate() {
   const memTotalVram = testResult?.memory_analysis.total_vram_gb ?? 0
   const memKvBudget = testResult?.memory_analysis.kv_cache_budget_gb ?? 0
 
+  // Disagg detail (present only when the estimate ran in disagg mode).
+  const disagg = testResult?.mode === 'disagg' ? testResult.disagg ?? null : null;
+  const isDisagg = disagg != null;
+
   // animated headline numbers
-  // Calculate real values from inference engine
+  // Calculate real values from inference engine. Disagg = sum of each pool's
+  // workers × gpus/worker; agg = tp × replicas × pp.
   const realGpuCount = testResult ?
-    testResult.memory_analysis.tp_size * testResult.memory_analysis.replicas * (testResult.parallelism_strategy.pp_size || 1) :
+    (isDisagg
+      ? disagg.prefill.workers * disagg.prefill.gpusPerWorker + disagg.decode.workers * disagg.decode.gpusPerWorker
+      : testResult.memory_analysis.tp_size * testResult.memory_analysis.replicas * (testResult.parallelism_strategy.pp_size || 1)) :
     0;
 
   const realWeightGB = testResult ?
@@ -590,9 +651,20 @@ export default function QuickEstimate() {
       ...(testWeightPrecision === 'MXFP4' && { gemm_quant_mode: 'mxfp4' }),
       ...(testWeightPrecision === 'NVFP4' && { gemm_quant_mode: 'nvfp4' }),
       ...(testKVCachePrecision === 'FP8' && { kvcache_quant_mode: 'fp8' }),
-      ...(testKVCachePrecision === 'NVFP4' && { kvcache_quant_mode: 'nvfp4' })
+      ...(testKVCachePrecision === 'NVFP4' && { kvcache_quant_mode: 'nvfp4' }),
+      ...(servingMode === 'disagg' && {
+        mode: 'disagg',
+        prefill_tp_size: parsePerfPhase(prefillCfg).tp,
+        prefill_pp_size: parsePerfPhase(prefillCfg).pp,
+        prefill_num_workers: parsePerfPhase(prefillCfg).workers,
+        prefill_batch_size: parsePerfPhase(prefillCfg).batch,
+        decode_tp_size: parsePerfPhase(decodeCfg).tp,
+        decode_pp_size: parsePerfPhase(decodeCfg).pp,
+        decode_num_workers: parsePerfPhase(decodeCfg).workers,
+        decode_batch_size: parsePerfPhase(decodeCfg).batch,
+      })
     };
-  }, [model, gpu, inferenceBackend, testISL, testOSL, testConcurrentUsers, testResult, testTpSize, testPpSize, currentAicGpu, testPrefix, backendVersion, testWeightPrecision, testKVCachePrecision]);
+  }, [model, gpu, inferenceBackend, testISL, testOSL, testConcurrentUsers, testResult, testTpSize, testPpSize, currentAicGpu, testPrefix, backendVersion, testWeightPrecision, testKVCachePrecision, servingMode, prefillCfg, decodeCfg]);
 
   // Copy API request body to clipboard
   const handleCopyAPIRequest = async () => {
@@ -1047,6 +1119,24 @@ export default function QuickEstimate() {
 
       </div>
 
+      {/* ---------- serving mode (agg / disagg) ---------- */}
+      <div className={`${styles.card}`} style={{ padding: '14px 18px', marginBottom: 12 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 12, flexWrap: 'wrap' }}>
+          <span style={{ fontSize: '12px', fontWeight: 600, fontFamily: 'var(--mono)', textTransform: 'uppercase', letterSpacing: '0.06em', color: '#3c3f42', whiteSpace: 'nowrap' }}>Serving mode:</span>
+          <Button variant={servingMode === 'agg' ? 'secondary' : 'tertiary'} size="sm" onClick={() => setServingMode('agg')}>Aggregated</Button>
+          <Button variant={servingMode === 'disagg' ? 'secondary' : 'tertiary'} size="sm" onClick={() => setServingMode('disagg')}>Disaggregated</Button>
+          {servingMode === 'disagg' && (
+            <span style={{ fontSize: '12px', color: '#54585c' }}>Prefill and decode run on separate GPU pools.</span>
+          )}
+        </div>
+        {servingMode === 'disagg' && (
+          <div style={{ marginTop: 14, display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 20 }}>
+            <PerfPhaseFields title="Prefill pool" cfg={prefillCfg} onChange={setPrefillCfg} />
+            <PerfPhaseFields title="Decode pool" cfg={decodeCfg} onChange={setDecodeCfg} />
+          </div>
+        )}
+      </div>
+
       {/* ---------- workload presets ---------- */}
       {hydrated && (
         <div style={{ display: 'flex', alignItems: 'center', gap: '8px', flexWrap: 'wrap', marginBottom: '12px' }}>
@@ -1212,7 +1302,11 @@ export default function QuickEstimate() {
               <span className={styles.tileValue}>{Math.round(gpus)}<span className={styles.tileUnit}>× {gpu}</span></span>
               <span className={styles.tileSub}>
                 {testResult ? (
-                  <>TP={testResult.memory_analysis.tp_size}{testResult.parallelism_strategy.pp_size > 1 ? ` × PP=${testResult.parallelism_strategy.pp_size}` : ''} × {testResult.memory_analysis.replicas} replica{testResult.memory_analysis.replicas > 1 ? 's' : ''} · {testConcurrentUsers} concurrent users</>
+                  isDisagg ? (
+                    <>disagg · prefill {disagg.prefill.workers}×{disagg.prefill.gpusPerWorker} + decode {disagg.decode.workers}×{disagg.decode.gpusPerWorker} · {testConcurrentUsers} concurrent users</>
+                  ) : (
+                    <>TP={testResult.memory_analysis.tp_size}{testResult.parallelism_strategy.pp_size > 1 ? ` × PP=${testResult.parallelism_strategy.pp_size}` : ''} × {testResult.memory_analysis.replicas} replica{testResult.memory_analysis.replicas > 1 ? 's' : ''} · {testConcurrentUsers} concurrent users</>
+                  )
                 ) : (
                   <>Configure workload below to see results</>
                 )}
@@ -1223,7 +1317,13 @@ export default function QuickEstimate() {
             <>
               <div className={styles.backTitle}>How we got {Math.round(gpus)}</div>
               <div className={styles.formula}>
-                {testResult ? (
+                {testResult && isDisagg ? (
+                  <>
+                    prefill = <span className={styles.em}>{disagg.prefill.workers} × {disagg.prefill.gpusPerWorker} = {disagg.prefill.workers * disagg.prefill.gpusPerWorker}</span> GPUs<br />
+                    decode = <span className={styles.em}>{disagg.decode.workers} × {disagg.decode.gpusPerWorker} = {disagg.decode.workers * disagg.decode.gpusPerWorker}</span> GPUs<br />
+                    total = <span className={styles.em}>{disagg.prefill.workers * disagg.prefill.gpusPerWorker} + {disagg.decode.workers * disagg.decode.gpusPerWorker} = {Math.round(gpus)} GPUs</span>
+                  </>
+                ) : testResult ? (
                   <>
                     weight memory = <span className={styles.em}>{testResult.memory_analysis.weight_gb.toFixed(1)} GB</span><br />
                     usable / GPU = <span className={styles.em}>{memUsablePerGpu.toFixed(0)} GB</span><br />
@@ -1248,6 +1348,7 @@ export default function QuickEstimate() {
         />
         </div>
 
+        {!isDisagg && (
         <div>
           <FlipTile
             front={
@@ -1291,7 +1392,36 @@ export default function QuickEstimate() {
           }
         />
         </div>
+        )}
 
+        {isDisagg && ([['Prefill', disagg.prefill], ['Decode', disagg.decode]] as const).map(([name, ph]) => (
+          <div key={name}>
+            <FlipTile
+              front={
+                <>
+                  <span className={styles.tileLabel}><MicrochipIcon /> {name} pool</span>
+                  <span className={styles.tileValue}>{ph.workers * ph.gpusPerWorker}<span className={styles.tileUnit}>GPUs</span></span>
+                  <span className={styles.tileSub}>
+                    {ph.workers} × {ph.gpusPerWorker}/worker · TP{ph.tp_size}{ph.pp_size > 1 ? ` · PP${ph.pp_size}` : ''} · bs {ph.batch_size}
+                  </span>
+                </>
+              }
+              back={
+                <>
+                  <div className={styles.backTitle}>{name} pool</div>
+                  <div className={styles.formula}>
+                    gpus/worker = {ph.tp_size}{ph.pp_size > 1 ? ` × ${ph.pp_size}` : ''} = <span className={styles.em}>{ph.gpusPerWorker}</span><br />
+                    workers = <span className={styles.em}>{ph.workers}</span> · bs = <span className={styles.em}>{ph.batch_size}</span><br />
+                    {ph.memory_gb != null && <>peak mem/GPU = <span className={styles.em}>{ph.memory_gb.toFixed(1)} GB</span><br /></>}
+                    pool = <span className={styles.em}>{ph.workers} × {ph.gpusPerWorker} = {ph.workers * ph.gpusPerWorker} GPUs</span>
+                  </div>
+                </>
+              }
+            />
+          </div>
+        ))}
+
+        {!isDisagg && (
         <div>
           <FlipTile
             front={
@@ -1334,6 +1464,7 @@ export default function QuickEstimate() {
             }
           />
         </div>
+        )}
 
         {costingsEnabled && gpuPricePerHour == null && !costings.isLoading && (
           <div style={{
@@ -1472,8 +1603,8 @@ export default function QuickEstimate() {
       </div>
       )}
 
-      {/* ---------- Why this GPU count ---------- */}
-      {testResult && (
+      {/* ---------- Why this GPU count (agg only) ---------- */}
+      {testResult && !isDisagg && (
         <div className={styles.card} style={{ marginBottom: 20 }}>
           <div
             className={styles.cardHead}
@@ -1569,8 +1700,8 @@ export default function QuickEstimate() {
         </div>
       )}
 
-      {/* ---------- Memory Layout ---------- */}
-      {testResult && (
+      {/* ---------- Memory Layout (agg only) ---------- */}
+      {testResult && !isDisagg && (
         <div className={styles.card} style={{ marginBottom: 20 }}>
           <div className={styles.cardHead}>
             <span className={styles.cardTitle}>Memory layout per GPU</span>

--- a/app/performance/PerformanceEstimate.tsx
+++ b/app/performance/PerformanceEstimate.tsx
@@ -1143,8 +1143,8 @@ export default function QuickEstimate() {
       <div className={`${styles.card}`} style={{ padding: '14px 18px', marginBottom: 12 }}>
         <div style={{ display: 'flex', alignItems: 'center', gap: 12, flexWrap: 'wrap' }}>
           <span style={{ fontSize: '12px', fontWeight: 600, fontFamily: 'var(--mono)', textTransform: 'uppercase', letterSpacing: '0.06em', color: '#3c3f42', whiteSpace: 'nowrap' }}>Serving mode:</span>
-          <Button variant={servingMode === 'agg' ? 'secondary' : 'tertiary'} size="sm" onClick={() => setServingMode('agg')}>Aggregated</Button>
-          <Button variant={servingMode === 'disagg' ? 'secondary' : 'tertiary'} size="sm" onClick={() => setServingMode('disagg')}>Disaggregated</Button>
+          <Button variant={servingMode === 'agg' ? 'secondary' : 'tertiary'} size="sm" onClick={() => { setServingMode('agg'); setTestResult(null); }}>Aggregated</Button>
+          <Button variant={servingMode === 'disagg' ? 'secondary' : 'tertiary'} size="sm" onClick={() => { setServingMode('disagg'); setTestResult(null); }}>Disaggregated</Button>
           {servingMode === 'disagg' && (
             <span style={{ fontSize: '12px', color: '#54585c' }}>Prefill and decode run on separate GPU pools.</span>
           )}
@@ -1951,14 +1951,29 @@ export default function QuickEstimate() {
         <Button variant="secondary" onClick={handleCopyCLICommand} isDisabled={!testResult}>
           Copy CLI command
         </Button>
-        <Button variant="secondary" onClick={handleExportToSheets} isDisabled={!testResult || !catalogGpuForPricing || gpuPricePerHour == null}>
+        <Button
+          variant="secondary"
+          onClick={handleExportToSheets}
+          isDisabled={!testResult || !catalogGpuForPricing || gpuPricePerHour == null || isDisagg}
+          title={isDisagg ? 'Export currently supports aggregated results only' : undefined}
+        >
           Export to Sheets
         </Button>
         <span className={styles.footerSpacer} />
-        <Button variant="primary" onClick={() => setShowSaveModal(true)} isDisabled={!testResult || !catalogGpuForPricing || gpuPricePerHour == null}>
+        <Button
+          variant="primary"
+          onClick={() => setShowSaveModal(true)}
+          isDisabled={!testResult || !catalogGpuForPricing || gpuPricePerHour == null || isDisagg}
+          title={isDisagg ? 'Saving currently supports aggregated results only' : undefined}
+        >
           Save estimate{savedCount > 0 && ` (${savedCount})`}
         </Button>
       </div>
+      {isDisagg && (
+        <div style={{ marginTop: 6, fontSize: '12px', color: '#54585c' }}>
+          Save and export currently support aggregated results only.
+        </div>
+      )}
 
       {/* Save estimate modal */}
       <SaveEstimateModal

--- a/app/recommend/AdvancedEstimate.module.css
+++ b/app/recommend/AdvancedEstimate.module.css
@@ -273,6 +273,28 @@
 @media (max-width: 1100px) { .tilesGrid { grid-template-columns: 1fr 1fr; } }
 @media (max-width: 600px)  { .tilesGrid { grid-template-columns: 1fr; } }
 
+/* ---------- disagg phase tiles ---------- */
+.phaseSection { margin: -8px 0 24px; }
+.phaseHeading {
+  font-family: var(--mono); font-size: 12px; font-weight: 600;
+  letter-spacing: 0.06em; text-transform: uppercase; color: var(--t2);
+  margin-bottom: 12px; display: flex; align-items: baseline; gap: 10px; flex-wrap: wrap;
+}
+.phaseHeading span {
+  font-weight: 500; text-transform: none; letter-spacing: 0; color: var(--t3);
+  font-size: 12px;
+}
+.phaseGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 16px;
+}
+.phaseGrid > div { transition: opacity 200ms ease-out; }
+.phaseGrid:hover > div:not(:hover) { opacity: 0.85; }
+@media (prefers-reduced-motion: reduce) {
+  .phaseGrid:hover > div:not(:hover) { opacity: 1; }
+}
+
 .flip {
   perspective: 1100px;
   cursor: pointer !important;

--- a/app/recommend/AdvancedEstimate.tsx
+++ b/app/recommend/AdvancedEstimate.tsx
@@ -16,6 +16,7 @@ import { InfoStrip, InfoStripAction } from '@/components/ui/InfoStrip';
 import styles from './AdvancedEstimate.module.css';
 import { fetchModelConfig } from '@/lib/huggingface/fetch-config';
 import { useRecommend } from '@/contexts/RecommendContext';
+import { isMoeConfig, type PhaseConfig } from '@/lib/api/recommend';
 import { useAicCatalog } from '@/lib/hooks/useAicCatalog';
 import { useSettings } from '@/contexts/SettingsContext';
 import { useCostings, resolveCloudRate } from '@/lib/hooks/useCostings';
@@ -57,6 +58,74 @@ function FlipTile({ dark = false, front, back }: {
         <span className={styles.seeMath}>↻ flip back</span>
       </div>
     </div>
+  );
+}
+
+// ─── Phase (disagg pool) tile ────────────────────────────────────────────────
+
+/**
+ * Compact parallelism label for a worker/phase. Shows attention dims (TP/PP/DP)
+ * and, for MoE, expert dims separately — EP (moe_ep) and ETP (moe_tp).
+ */
+function parallelLabel(p: {
+  tensorParallelSize: number
+  pipelineParallelSize: number
+  dataParallelSize: number
+  contextParallelSize?: number
+  moeExpertParallelSize: number | null
+  moeTensorParallelSize: number | null
+}): string {
+  const parts = [`TP${p.tensorParallelSize}`, `PP${p.pipelineParallelSize}`];
+  if (p.dataParallelSize > 1) parts.push(`DP${p.dataParallelSize}`);
+  if (p.contextParallelSize != null && p.contextParallelSize > 1) parts.push(`CP${p.contextParallelSize}`);
+  if (isMoeConfig(p.moeTensorParallelSize, p.moeExpertParallelSize)) {
+    if (p.moeExpertParallelSize != null && p.moeExpertParallelSize > 1) parts.push(`EP${p.moeExpertParallelSize}`);
+    if (p.moeTensorParallelSize != null && p.moeTensorParallelSize > 1) parts.push(`ETP${p.moeTensorParallelSize}`);
+  }
+  return parts.join(' · ');
+}
+
+function PhaseTile({ name, icon, phase }: {
+  name: string; icon: React.ReactNode; phase: PhaseConfig;
+}) {
+  const poolGpus = phase.workers * phase.gpusPerWorker;
+  // gpus/worker dims that are > 1 (matches the SDK's tp·pp·dp·cp definition).
+  const gpwFactors = [
+    ['TP', phase.tensorParallelSize],
+    ['PP', phase.pipelineParallelSize],
+    ['DP', phase.dataParallelSize],
+    ['CP', phase.contextParallelSize],
+  ].filter(([, v]) => (v as number) > 1);
+  const gpwMath = gpwFactors.length > 0
+    ? gpwFactors.map(([, v]) => v).join(' × ')
+    : '1';
+  return (
+    <FlipTile
+      front={
+        <>
+          <span className={styles.tileLabel}>{icon} {name}</span>
+          <span className={styles.tileValue}>
+            {poolGpus}<span className={styles.tileUnit}>GPUs</span>
+          </span>
+          <span className={styles.tileSub}>
+            {phase.workers} worker{phase.workers === 1 ? '' : 's'} × {phase.gpusPerWorker} GPU/worker · {parallelLabel(phase)}
+            {phase.batchSize != null ? ` · bs ${phase.batchSize}` : ''}
+          </span>
+        </>
+      }
+      back={
+        <>
+          <div className={styles.backTitle}>{name} pool</div>
+          <div className={styles.formula}>
+            {parallelLabel(phase)}<br />
+            gpus/worker = {gpwMath} = <span className={styles.em}>{phase.gpusPerWorker}</span><br />
+            workers = <span className={styles.em}>{phase.workers}</span>
+            {phase.batchSize != null && <> · bs = <span className={styles.em}>{phase.batchSize}</span></>}<br />
+            pool = <span className={styles.em}>{phase.workers} × {phase.gpusPerWorker} = {poolGpus} GPUs</span>
+          </div>
+        </>
+      }
+    />
   );
 }
 
@@ -322,7 +391,9 @@ export default function AdvancedEstimate() {
     ? `${resolvedCloudRate.provider.replace('.', ' · ')} ${resolvedCloudRate.kind === 'spot' ? 'spot' : 'on-demand'}`
     : amortizedHwPerHour != null ? 'amortized hardware (5-year)'
     : '';
-  const numGpus = result?.recommendation.totalGpus ?? 0;
+  // Cost is for the whole deployment, so use the aggregate GPU total
+  // (replicas × gpus/replica), not per-replica/per-worker.
+  const numGpus = result?.recommendation.gpusNeeded ?? 0;
   const monthlyCost = pricePerHour != null ? numGpus * pricePerHour * HOURS_PER_MONTH : null;
 
   return (
@@ -515,25 +586,66 @@ export default function AdvancedEstimate() {
               dark
               front={
                 <>
-                  <span className={styles.tileLabel}><MicrochipIcon /> GPUs required</span>
+                  <span className={styles.tileLabel}>
+                    <MicrochipIcon /> GPUs required
+                    <Label isCompact color={result.mode === 'disagg' ? 'purple' : 'blue'} style={{ marginLeft: 'auto' }}>
+                      {result.mode === 'disagg' ? 'disagg' : 'agg'}
+                    </Label>
+                  </span>
                   <span className={styles.tileValue}>
                     {gpuCount}<span className={styles.tileUnit}>× {currentGpuOption.label}</span>
                   </span>
                   <span className={styles.tileSub}>
-                    TP {result.recommendation.tensorParallelSize} · PP {result.recommendation.pipelineParallelSize} · DP {result.recommendation.dataParallelSize} · {result.performance.concurrency} concurrent users
+                    {result.mode === 'disagg'
+                      ? `${result.recommendation.replicasNeeded} replicas × ${result.recommendation.gpusPerReplica} GPUs/replica · ${result.performance.concurrency} concurrent users`
+                      : `${parallelLabel(result.recommendation)} · ${result.performance.concurrency} concurrent users`}
                   </span>
                 </>
               }
               back={
-                <>
-                  <div className={styles.backTitle}>GPU topology</div>
-                  <div className={styles.formula}>
-                    tensor parallel = <span className={styles.em}>{result.recommendation.tensorParallelSize}</span><br />
-                    pipeline parallel = <span className={styles.em}>{result.recommendation.pipelineParallelSize}</span><br />
-                    data parallel = <span className={styles.em}>{result.recommendation.dataParallelSize}</span><br />
-                    total = TP×PP×DP = <span className={styles.em}>{result.recommendation.totalGpus} GPUs</span>
-                  </div>
-                </>
+                result.mode === 'disagg' ? (
+                  <>
+                    <div className={styles.backTitle}>Disagg topology (xPyD)</div>
+                    <div className={styles.formula}>
+                      {([
+                        ['prefill', result.phases.prefill],
+                        ['decode', result.phases.decode],
+                        ['encode', result.phases.encode],
+                      ] as const)
+                        .filter(([, p]) => p != null)
+                        .map(([label, p]) => (
+                          <React.Fragment key={label}>
+                            {label}: <span className={styles.em}>{p!.workers} × {p!.gpusPerWorker} = {p!.workers * p!.gpusPerWorker}</span> GPUs<br />
+                          </React.Fragment>
+                        ))}
+                      gpus/replica ={' '}
+                      <span className={styles.em}>
+                        {([result.phases.prefill, result.phases.decode, result.phases.encode]
+                          .filter((p): p is PhaseConfig => p != null)
+                          .map(p => p.workers * p.gpusPerWorker)
+                          .join(' + '))} = {result.recommendation.gpusPerReplica}
+                      </span><br />
+                      total = <span className={styles.em}>{result.recommendation.gpusPerReplica} × {result.recommendation.replicasNeeded} replicas = {result.recommendation.gpusNeeded} GPUs</span>
+                    </div>
+                  </>
+                ) : (
+                  <>
+                    <div className={styles.backTitle}>GPU topology</div>
+                    <div className={styles.formula}>
+                      tensor parallel = <span className={styles.em}>{result.recommendation.tensorParallelSize}</span><br />
+                      pipeline parallel = <span className={styles.em}>{result.recommendation.pipelineParallelSize}</span><br />
+                      data parallel = <span className={styles.em}>{result.recommendation.dataParallelSize}</span><br />
+                      {result.recommendation.contextParallelSize > 1 &&
+                        <>context parallel = <span className={styles.em}>{result.recommendation.contextParallelSize}</span><br /></>}
+                      {result.recommendation.moeExpertParallelSize != null && result.recommendation.moeExpertParallelSize > 1 &&
+                        <>expert parallel (EP) = <span className={styles.em}>{result.recommendation.moeExpertParallelSize}</span><br /></>}
+                      {result.recommendation.moeTensorParallelSize != null && result.recommendation.moeTensorParallelSize > 1 &&
+                        <>expert tensor parallel (ETP) = <span className={styles.em}>{result.recommendation.moeTensorParallelSize}</span><br /></>}
+                      gpus/worker = <span className={styles.em}>{result.recommendation.gpusPerReplica}</span><br />
+                      total = <span className={styles.em}>{result.recommendation.gpusPerReplica} × {result.recommendation.replicasNeeded} replicas = {result.recommendation.gpusNeeded} GPUs</span>
+                    </div>
+                  </>
+                )
               }
             />
 
@@ -593,29 +705,45 @@ export default function AdvancedEstimate() {
               }
             />
 
-            {/* Est. Memory */}
+            {/* Peak memory per GPU */}
             <FlipTile
               front={
                 <>
-                  <span className={styles.tileLabel}><MemoryIcon /> Est. memory</span>
+                  <span className={styles.tileLabel}><MemoryIcon /> Peak mem / GPU</span>
                   <span className={styles.tileValue}>
                     {memVal}<span className={styles.tileUnit}>GB</span>
                   </span>
                   <span className={styles.tileSub}>
-                    {result.recommendation.totalGpus === 1
-                      ? '1 GPU per model instance'
-                      : `${result.recommendation.totalGpus} GPUs per model instance`}
+                    {result.mode === 'disagg' ? 'worst case across pools' : 'peak usage per GPU'}
                   </span>
                 </>
               }
               back={
                 <>
-                  <div className={styles.backTitle}>Memory estimate</div>
+                  <div className={styles.backTitle}>Memory per GPU</div>
                   <div className={styles.formula}>
-                    memory: <span className={styles.em}>{result.memory.value.toFixed(1)} {result.memory.unit}</span><br />
-                    scope: <span className={styles.em}>{result.memory.scope}</span><br />
-                    GPUs: <span className={styles.em}>{result.recommendation.totalGpus}</span><br />
-                    ~{(result.memory.value / result.recommendation.totalGpus).toFixed(1)} GB/GPU
+                    {result.mode === 'disagg' ? (
+                      <>
+                        {([
+                          ['prefill', result.phases.prefill],
+                          ['decode', result.phases.decode],
+                          ['encode', result.phases.encode],
+                        ] as const)
+                          .filter(([, p]) => p != null && p.memoryGb != null)
+                          .map(([label, p]) => (
+                            <React.Fragment key={label}>
+                              {label}: <span className={styles.em}>{p!.memoryGb!.toFixed(1)} GB/GPU</span><br />
+                            </React.Fragment>
+                          ))}
+                        peak = <span className={styles.em}>{result.memory.value.toFixed(1)} GB/GPU</span> (worst case)
+                      </>
+                    ) : (
+                      <>
+                        peak usage = <span className={styles.em}>{result.memory.value.toFixed(1)} {result.memory.unit}</span> per GPU<br />
+                        checked against a single GPU&apos;s HBM<br />
+                        {result.recommendation.gpusPerReplica} GPUs per replica
+                      </>
+                    )}
                   </div>
                 </>
               }
@@ -649,6 +777,19 @@ export default function AdvancedEstimate() {
               />
             )}
           </div>
+
+          {result.mode === 'disagg' && (result.phases.prefill || result.phases.decode || result.phases.encode) && (
+            <div className={styles.phaseSection}>
+              <div className={styles.phaseHeading}>
+                Disaggregated pools <span>per replica — {result.recommendation.gpusPerReplica} GPUs</span>
+              </div>
+              <div className={styles.phaseGrid}>
+                {result.phases.prefill && <PhaseTile name="Prefill" icon={<MicrochipIcon />} phase={result.phases.prefill} />}
+                {result.phases.decode && <PhaseTile name="Decode" icon={<MicrochipIcon />} phase={result.phases.decode} />}
+                {result.phases.encode && <PhaseTile name="Encode" icon={<MicrochipIcon />} phase={result.phases.encode} />}
+              </div>
+            </div>
+          )}
 
           {costingsEnabled && monthlyCost == null && (
             <div className={styles.card} style={{ marginBottom: 24, fontSize: '13px', color: '#54585c' }}>

--- a/lib/api/estimate-adapter.ts
+++ b/lib/api/estimate-adapter.ts
@@ -8,7 +8,7 @@
  * for an optimal config.
  */
 
-import type { InferenceConfigResult } from '@/lib/gpu-math/inference-config/types'
+import type { EstimatePhase, InferenceConfigResult } from '@/lib/gpu-math/inference-config/types'
 
 const GB = 1_073_741_824
 
@@ -38,6 +38,17 @@ export interface EstimateAdapterInput {
   prefix?: number
   kvcache_quant_mode?: string | null
   gemm_quant_mode?: string | null
+  // Disagg: when mode='disagg', prefill/decode drive separate pools.
+  mode?: 'agg' | 'disagg'
+  prefill?: EstimatePhaseInput
+  decode?: EstimatePhaseInput
+}
+
+export interface EstimatePhaseInput {
+  tp: number
+  pp: number
+  workers: number
+  batch: number
 }
 
 function isMoeConfig(config: Record<string, unknown> | null | undefined): boolean {
@@ -93,6 +104,20 @@ export async function fetchEstimateAsInferenceResult(
     body.model_config = input.hf_model_config
   }
 
+  // Disagg: send per-pool parallelism. The backend runs cli_estimate in
+  // mode='disagg' and returns prefill_config / decode_config.
+  if (input.mode === 'disagg' && input.prefill && input.decode) {
+    body.mode = 'disagg'
+    body.prefill_tp_size = input.prefill.tp
+    body.prefill_pp_size = input.prefill.pp
+    body.prefill_num_workers = input.prefill.workers
+    body.prefill_batch_size = input.prefill.batch
+    body.decode_tp_size = input.decode.tp
+    body.decode_pp_size = input.decode.pp
+    body.decode_num_workers = input.decode.workers
+    body.decode_batch_size = input.decode.batch
+  }
+
   // MoE models require at least one of moe_ep_size / moe_tp_size.
   // Prefer explicit values; fall back to auto-detecting from hf_model_config.
   if (input.moe_ep_size != null) {
@@ -141,7 +166,27 @@ export async function fetchEstimateAsInferenceResult(
   // With pipeline parallel, weights are sharded across TP×PP GPUs
   const shardCount = tp * pp
 
+  // Disagg: fold the per-pool worker configs into EstimatePhase records.
+  const buildPhase = (wc: Record<string, unknown> | null | undefined, fallback: EstimatePhaseInput): EstimatePhase => {
+    const tpv = (wc?.tp as number) ?? fallback.tp
+    const ppv = (wc?.pp as number) ?? fallback.pp
+    return {
+      workers: (wc?.num_workers as number) ?? fallback.workers,
+      gpusPerWorker: tpv * ppv,
+      tp_size: tpv,
+      pp_size: ppv,
+      batch_size: (wc?.batch_size as number) ?? fallback.batch,
+      memory_gb: (wc?.memory_gb as number | null) ?? null,
+    }
+  }
+  const isDisagg = data.mode === 'disagg' && !!input.prefill && !!input.decode
+  const disagg = isDisagg
+    ? { prefill: buildPhase(data.prefill_config, input.prefill!), decode: buildPhase(data.decode_config, input.decode!) }
+    : undefined
+
   return {
+    mode: isDisagg ? 'disagg' : 'agg',
+    disagg,
     memory_analysis: {
       weight_gb: weightGb,
       weight_gb_per_gpu: weightGb / shardCount,

--- a/lib/api/estimate-adapter.ts
+++ b/lib/api/estimate-adapter.ts
@@ -184,6 +184,11 @@ export async function fetchEstimateAsInferenceResult(
     ? { prefill: buildPhase(data.prefill_config, input.prefill!), decode: buildPhase(data.decode_config, input.decode!) }
     : undefined
 
+  const warnings: string[] = hasBreakdown ? [] : ['Memory breakdown estimated (no backend_version specified).']
+  if (input.mode === 'disagg' && !isDisagg) {
+    warnings.push('Disaggregated mode was requested but the backend returned an aggregated estimate.')
+  }
+
   return {
     mode: isDisagg ? 'disagg' : 'agg',
     disagg,
@@ -221,6 +226,6 @@ export async function fetchEstimateAsInferenceResult(
       dcgm_metrics: ['DCGM_FI_PROF_GR_ENGINE_ACTIVE', 'DCGM_FI_DEV_FB_USED'],
       vllm_metrics: ['vllm:num_requests_running', 'vllm:gpu_cache_usage_perc'],
     },
-    warnings: hasBreakdown ? [] : ['Memory breakdown estimated (no backend_version specified).'],
+    warnings,
   }
 }

--- a/lib/api/recommend.ts
+++ b/lib/api/recommend.ts
@@ -7,16 +7,53 @@ interface RecommendWarning {
   message: string
 }
 
+export type ServingMode = 'agg' | 'disagg'
+
+/**
+ * One worker role in a disaggregated deployment (prefill / decode / encode).
+ * `gpusPerWorker` = tp·pp·dp for dense models, or etp·ep·pp for MoE models
+ * (see the aiconfigurator replica math). A replica's GPU count is the sum of
+ * `workers × gpusPerWorker` across all phases.
+ */
+export interface PhaseConfig {
+  workers: number
+  gpusPerWorker: number
+  tensorParallelSize: number
+  pipelineParallelSize: number
+  dataParallelSize: number
+  contextParallelSize: number
+  moeTensorParallelSize: number | null
+  moeExpertParallelSize: number | null
+  batchSize: number | null
+  memoryGb: number | null
+}
+
 export interface RecommendResult {
   requestId: string
   status: 'completed'
+  /** Serving mode the recommender chose. Disagg splits prefill/decode pools. */
+  mode: ServingMode
   recommendation: {
+    /** Aggregate total GPUs across all replicas and pools. */
     gpusNeeded: number
+    /** GPUs in one replica (the smallest scalable unit). */
+    gpusPerReplica: number
+    /** GPUs per worker (agg). Equals gpusPerReplica for disagg. */
     totalGpus: number
     replicasNeeded: number
     tensorParallelSize: number
     pipelineParallelSize: number
     dataParallelSize: number
+    contextParallelSize: number
+    moeTensorParallelSize: number | null
+    moeExpertParallelSize: number | null
+    batchSize: number | null
+  }
+  /** Per-phase pools (disagg only; all null for agg). Encode is future-ready. */
+  phases: {
+    prefill: PhaseConfig | null
+    decode: PhaseConfig | null
+    encode: PhaseConfig | null
   }
   performance: {
     ttftLatencyMs: number
@@ -30,9 +67,9 @@ export interface RecommendResult {
     tokensPerSecondPerUser: number
   }
   memory: {
+    /** Worst-case peak memory usage per GPU (GB). Checked against one GPU's HBM. */
     value: number
     unit: 'GB'
-    scope: 'unspecified'
   }
   metadata: {
     modelPath: string
@@ -60,6 +97,65 @@ export type RecommendResponse = RecommendResult | RecommendErrorResponse
 
 export function generateRequestId(): string {
   return 'size_' + crypto.randomUUID().replace(/-/g, '').slice(0, 12)
+}
+
+// ─── Phase (disagg worker) parsing ───────────────────────────────────────────
+
+/** Shape of a WorkerConfig as returned by the AIConfigurator gateway. */
+interface RawWorkerConfig {
+  tp?: number | null
+  pp?: number | null
+  dp?: number | null
+  cp?: number | null
+  moe_tp?: number | null
+  moe_ep?: number | null
+  num_workers?: number | null
+  batch_size?: number | null
+  memory_gb?: number | null
+}
+
+/**
+ * True when the model uses expert parallelism. Dense models report moe_tp/moe_ep
+ * as null or 1; a value > 1 on either dimension means the experts are split.
+ * Used only for labelling (EP/ETP) — NOT for the GPU-count math, where MoE
+ * expert dims are laid out within the tp×dp GPUs (they do not add GPUs).
+ */
+export function isMoeConfig(moeTp: number | null, moeEp: number | null): boolean {
+  return (moeTp != null && moeTp > 1) || (moeEp != null && moeEp > 1)
+}
+
+const dim = (v: number | null | undefined): number => (v != null && v > 0 ? v : 1)
+
+/**
+ * GPUs consumed by a single worker = tp·pp·dp·cp. This mirrors the
+ * aiconfigurator SDK's WORKER_GPU_DIMS = (tp, pp, dp, cp) exactly and applies to
+ * both dense and MoE models (for MoE, tp·pp·dp already equals etp·ep·pp; the
+ * expert dims do not multiply the GPU count). cp (context parallel) is included
+ * — omitting it undercounts prefill pools.
+ */
+function gpusPerWorker(tp: number, pp: number, dp: number, cp: number): number {
+  return tp * pp * dp * cp
+}
+
+/** Parse a gateway WorkerConfig into a PhaseConfig, or null if absent. */
+function parsePhase(raw: RawWorkerConfig | null | undefined): PhaseConfig | null {
+  if (!raw || raw.tp == null) return null
+  const tp = dim(raw.tp)
+  const pp = dim(raw.pp)
+  const dp = dim(raw.dp)
+  const cp = dim(raw.cp)
+  return {
+    workers: raw.num_workers ?? 1,
+    gpusPerWorker: gpusPerWorker(tp, pp, dp, cp),
+    tensorParallelSize: tp,
+    pipelineParallelSize: pp,
+    dataParallelSize: dp,
+    contextParallelSize: cp,
+    moeTensorParallelSize: raw.moe_tp ?? null,
+    moeExpertParallelSize: raw.moe_ep ?? null,
+    batchSize: raw.batch_size ?? null,
+    memoryGb: raw.memory_gb ?? null,
+  }
 }
 
 // ─── Service ─────────────────────────────────────────────────────────────────
@@ -141,20 +237,43 @@ export async function callRecommend(
   }
 
   const best = configs[0]
+  const chosenMode = typeof rawData.chosen_mode === 'string' ? rawData.chosen_mode : 'agg'
+  const mode: ServingMode = chosenMode.startsWith('disagg') ? 'disagg' : 'agg'
+
   const totalGpusNeeded = (best.total_gpus_needed as number) ?? 0
-  const numTotalGpus = (best.num_total_gpus as number) ?? totalGpusNeeded
-  const tp = (best.tp as number) ?? 1
-  const pp = (best.pp as number) ?? 1
-  const dp = (best.dp as number) ?? 1
   const replicasNeeded = (best.replicas_needed as number) ?? 1
 
+  const prefill = parsePhase(best.prefill_config as RawWorkerConfig | undefined)
+  const decode = parsePhase(best.decode_config as RawWorkerConfig | undefined)
+  const encode = parsePhase(best.encode_config as RawWorkerConfig | undefined)
+
+  const tp = dim(best.tp as number | undefined)
+  const pp = dim(best.pp as number | undefined)
+  const dp = dim(best.dp as number | undefined)
+  const cp = dim(best.cp as number | undefined)
+  const moeTp = (best.moe_tp as number | null) ?? null
+  const moeEp = (best.moe_ep as number | null) ?? null
+  const batchSize = (best.bs as number | null) ?? null
+
   const warnings: RecommendWarning[] = []
-  const parallelismProduct = tp * pp * dp
-  if (parallelismProduct !== numTotalGpus) {
-    warnings.push({
-      code: 'GPU_TOPOLOGY_MISMATCH',
-      message: `Parallelism dimensions (TP=${tp} x PP=${pp} x DP=${dp} = ${parallelismProduct}) do not equal GPUs per worker (${numTotalGpus})`,
-    })
+  let gpusPerReplica: number
+  if (mode === 'disagg') {
+    // A replica is one prefill/decode(/encode) set: sum of workers × gpus/worker.
+    gpusPerReplica = [prefill, decode, encode].reduce(
+      (sum, phase) => sum + (phase ? phase.workers * phase.gpusPerWorker : 0),
+      0,
+    )
+  } else {
+    // Agg: gpus/replica == gpus/worker == num_total_gpus (tp·pp·dp·cp).
+    const numTotalGpus = (best.num_total_gpus as number) ?? gpusPerWorker(tp, pp, dp, cp)
+    gpusPerReplica = numTotalGpus
+    const parallelismProduct = gpusPerWorker(tp, pp, dp, cp)
+    if (parallelismProduct !== numTotalGpus) {
+      warnings.push({
+        code: 'GPU_TOPOLOGY_MISMATCH',
+        message: `Parallelism dimensions (TP=${tp} x PP=${pp} x DP=${dp} x CP=${cp} = ${parallelismProduct}) do not equal GPUs per worker (${numTotalGpus})`,
+      })
+    }
   }
 
   const durationMs = Math.round(performance.now() - startTime)
@@ -162,14 +281,21 @@ export async function callRecommend(
   return {
     requestId,
     status: 'completed',
+    mode,
     recommendation: {
       gpusNeeded: totalGpusNeeded,
-      totalGpus: numTotalGpus,
+      gpusPerReplica,
+      totalGpus: gpusPerReplica,
       replicasNeeded,
       tensorParallelSize: tp,
       pipelineParallelSize: pp,
       dataParallelSize: dp,
+      contextParallelSize: cp,
+      moeTensorParallelSize: moeTp,
+      moeExpertParallelSize: moeEp,
+      batchSize,
     },
+    phases: { prefill, decode, encode },
     performance: {
       ttftLatencyMs: (best.ttft as number) ?? 0,
       tpotMs: (best.tpot as number) ?? 0,
@@ -184,7 +310,6 @@ export async function callRecommend(
     memory: {
       value: (best.memory as number) ?? 0,
       unit: 'GB',
-      scope: 'unspecified',
     },
     metadata: {
       modelPath: request.model_path,

--- a/lib/api/recommend.ts
+++ b/lib/api/recommend.ts
@@ -278,6 +278,12 @@ export async function callRecommend(
 
   const durationMs = Math.round(performance.now() - startTime)
 
+  // The gateway reports concurrency, request rate, and tokens/s per replica;
+  // scale to cluster totals so the headline matches the whole deployment.
+  // Per-GPU and per-user rates are already per-unit and stay as-is.
+  const clusterConcurrency = Math.round(((best.concurrency as number) ?? 0) * replicasNeeded)
+  const clusterTokensPerSecond = ((best.tokens_per_second as number) ?? 0) * replicasNeeded
+
   return {
     requestId,
     status: 'completed',
@@ -300,10 +306,10 @@ export async function callRecommend(
       ttftLatencyMs: (best.ttft as number) ?? 0,
       tpotMs: (best.tpot as number) ?? 0,
       requestLatencyMs: (best.request_latency as number) ?? 0,
-      concurrency: (best.concurrency as number) ?? 0,
+      concurrency: clusterConcurrency,
     },
     throughput: {
-      tokensPerSecond: (best.tokens_per_second as number) ?? 0,
+      tokensPerSecond: clusterTokensPerSecond,
       tokensPerSecondPerGpu: (best.tokens_per_second_per_gpu as number) ?? 0,
       tokensPerSecondPerUser: (best.tokens_per_second_per_user as number) ?? 0,
     },

--- a/lib/api/recommend.ts
+++ b/lib/api/recommend.ts
@@ -11,9 +11,9 @@ export type ServingMode = 'agg' | 'disagg'
 
 /**
  * One worker role in a disaggregated deployment (prefill / decode / encode).
- * `gpusPerWorker` = tp·pp·dp for dense models, or etp·ep·pp for MoE models
- * (see the aiconfigurator replica math). A replica's GPU count is the sum of
- * `workers × gpusPerWorker` across all phases.
+ * `gpusPerWorker` = tp·pp·dp·cp (the aiconfigurator WORKER_GPU_DIMS; for MoE this
+ * already equals etp·ep·pp — expert dims do not add GPUs). A replica's GPU count
+ * is the sum of `workers × gpusPerWorker` across all phases.
  */
 export interface PhaseConfig {
   workers: number

--- a/lib/gpu-math/inference-config/index.ts
+++ b/lib/gpu-math/inference-config/index.ts
@@ -5,5 +5,6 @@ export type {
   VLLMConfig,
   BottleneckAnalysis,
   ParallelismStrategy,
-  LLMDConfig
+  LLMDConfig,
+  EstimatePhase
 } from './types'

--- a/lib/gpu-math/inference-config/types.ts
+++ b/lib/gpu-math/inference-config/types.ts
@@ -94,12 +94,32 @@ export interface LLMDConfig {
   }
 }
 
+/**
+ * One disaggregated pool (prefill or decode) as returned by the /estimate API.
+ * gpusPerWorker = tp·pp; a pool consumes workers × gpusPerWorker GPUs.
+ */
+export interface EstimatePhase {
+  workers: number
+  gpusPerWorker: number
+  tp_size: number
+  pp_size: number
+  batch_size: number
+  memory_gb: number | null
+}
+
 export interface InferenceConfigResult {
   memory_analysis: MemoryAnalysis
   vllm_config: VLLMConfig
   parallelism_strategy: ParallelismStrategy
   bottleneck_analysis: BottleneckAnalysis
   llmd_config?: LLMDConfig
+  /** Serving mode. Defaults to 'agg' when absent. */
+  mode?: 'agg' | 'disagg'
+  /** Per-pool detail (disagg only). */
+  disagg?: {
+    prefill: EstimatePhase
+    decode: EstimatePhase
+  }
   diagnostics: {
     nvidia_smi_watch: string
     dcgm_metrics: string[]

--- a/services/aiconfigurator/tests/unit/tools/test_api_service.py
+++ b/services/aiconfigurator/tests/unit/tools/test_api_service.py
@@ -847,6 +847,47 @@ class TestEstimate:
         assert kwargs["tp_size"] == 2
         assert kwargs["batch_size"] == 128
 
+    @patch("tools.api_service.app.cli_estimate")
+    def test_disagg_mode(self, mock_estimate):
+        mock = MagicMock()
+        mock.ttft = 500.0
+        mock.tpot = 30.0
+        mock.power_w = 0.0
+        mock.raw = {
+            "ttft": 500.0, "tpot": 30.0, "request_latency": 30000.0,
+            "tokens/s": 1000.0, "tokens/s/gpu": 250.0, "tokens/s/user": 40.0,
+            "bs": np.int64(64), "system": "h200_sxm", "backend": "vllm",
+            "version": "0.24.0", "gemm": "bfloat16", "kvcache": "bfloat16",
+            "(p)memory": 60.0, "(d)memory": 72.5,
+        }
+        mock_estimate.return_value = mock
+        body = {
+            **VALID_ESTIMATE_BODY,
+            "mode": "disagg",
+            "prefill_tp_size": 1, "prefill_pp_size": 1,
+            "prefill_num_workers": 4, "prefill_batch_size": 1,
+            "decode_tp_size": 4, "decode_pp_size": 1,
+            "decode_num_workers": 1, "decode_batch_size": 64,
+        }
+        resp = client.post("/estimate", json=body)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["mode"] == "disagg"
+        # Top-level parallelism is None for disagg; see prefill/decode_config.
+        assert data["tp"] is None
+        assert data["prefill_config"]["tp"] == 1
+        assert data["prefill_config"]["num_workers"] == 4
+        assert data["prefill_config"]["batch_size"] == 1
+        assert data["decode_config"]["tp"] == 4
+        assert data["decode_config"]["batch_size"] == 64
+        # Per-GPU peak is the worst case across pools, not summed.
+        assert data["memory"] == pytest.approx(72.5)
+        # SDK invoked in disagg mode with the per-role params.
+        kwargs = mock_estimate.call_args.kwargs
+        assert kwargs["mode"] == "disagg"
+        assert kwargs["prefill_num_workers"] == 4
+        assert kwargs["decode_tp_size"] == 4
+
     def test_requires_model_path(self):
         body = {**VALID_ESTIMATE_BODY}
         del body["model_path"]

--- a/services/aiconfigurator/tests/unit/tools/test_api_service.py
+++ b/services/aiconfigurator/tests/unit/tools/test_api_service.py
@@ -712,12 +712,14 @@ class TestRecommendDisagg:
             "seq/s": 8.992, "seq/s/gpu": 4.496,
             "tokens/s/user": 40.527, "power_w": 0.0,
             "(p)tp": np.int64(1), "(p)pp": np.int64(1), "(p)dp": np.int64(1),
+            "(p)cp": np.int64(1), "(p)bs": np.int64(1),
             "(p)workers": np.int64(1), "(p)memory": 64.9,
             "(p)gemm": "bfloat16", "(p)kvcache": "bfloat16",
             "(p)fmha": "bfloat16", "(p)moe": "bfloat16", "(p)comm": "half",
             "(p)version": "0.24.0",
-            "(d)tp": np.int64(1), "(d)pp": np.int64(1), "(d)dp": np.int64(1),
-            "(d)workers": np.int64(1), "(d)memory": 64.9,
+            "(d)tp": np.int64(4), "(d)pp": np.int64(1), "(d)dp": np.int64(1),
+            "(d)cp": np.int64(1), "(d)bs": np.int64(36),
+            "(d)workers": np.int64(1), "(d)memory": 70.1,
             "(d)gemm": "bfloat16", "(d)version": "0.24.0",
         }
         result = make_mock_cli_result([disagg_row])
@@ -734,9 +736,15 @@ class TestRecommendDisagg:
         assert cfg["prefill_config"] is not None
         assert cfg["decode_config"] is not None
         assert cfg["prefill_config"]["tp"] == 1
-        assert cfg["decode_config"]["tp"] == 1
+        assert cfg["decode_config"]["tp"] == 4
+        # Batch size and context parallel are surfaced per worker role.
+        assert cfg["prefill_config"]["batch_size"] == 1
+        assert cfg["decode_config"]["batch_size"] == 36
+        assert cfg["prefill_config"]["cp"] == 1
         assert cfg["total_gpus_needed"] == 6
-        assert cfg["memory"] == pytest.approx(129.8)
+        # Per-GPU peak memory is the worst-case across pools, NOT the sum
+        # (each (x)memory is checked against a single GPU's capacity).
+        assert cfg["memory"] == pytest.approx(70.1)
 
     @patch("tools.api_service.app.cli_recommend")
     def test_agg_result_has_no_prefill_decode(self, mock_recommend):

--- a/services/aiconfigurator/tests/unit/tools/test_api_service.py
+++ b/services/aiconfigurator/tests/unit/tools/test_api_service.py
@@ -888,6 +888,11 @@ class TestEstimate:
         assert kwargs["prefill_num_workers"] == 4
         assert kwargs["decode_tp_size"] == 4
 
+    def test_invalid_mode_rejected(self):
+        body = {**VALID_ESTIMATE_BODY, "mode": "bogus"}
+        resp = client.post("/estimate", json=body)
+        assert resp.status_code == 422
+
     def test_requires_model_path(self):
         body = {**VALID_ESTIMATE_BODY}
         del body["model_path"]

--- a/services/aiconfigurator/tools/api_service/app.py
+++ b/services/aiconfigurator/tools/api_service/app.py
@@ -143,9 +143,11 @@ class WorkerConfig(BaseModel):
     tp: int | None = None
     pp: int | None = None
     dp: int | None = None
+    cp: int | None = None
     moe_tp: int | None = None
     moe_ep: int | None = None
     num_workers: int | None = None
+    batch_size: int | None = None
     memory_gb: float | None = None
     gemm: str | None = None
     kvcache: str | None = None
@@ -167,6 +169,7 @@ class RecommendConfig(BaseModel):
     moe_tp: int | None = None
     moe_ep: int | None = None
     cp: int | None = None
+    bs: int | None = None
     ttft: float | None = None
     tpot: float | None = None
     request_latency: float | None = None
@@ -285,7 +288,7 @@ _COLUMN_MAP = {
 
 _INT_FIELDS = frozenset({
     "total_gpus_needed", "replicas_needed", "num_total_gpus",
-    "tp", "pp", "dp", "moe_tp", "moe_ep", "cp", "concurrency",
+    "tp", "pp", "dp", "moe_tp", "moe_ep", "cp", "bs", "concurrency",
 })
 
 _SM_ARCHITECTURE = {
@@ -371,9 +374,11 @@ def _worker_config_from_row(row: pd.Series, prefix: str, req: RecommendRequest) 
         tp=tp,
         pp=_coerce_int(g("pp")),
         dp=_coerce_int(g("dp")),
+        cp=_coerce_int(g("cp")),
         moe_tp=_coerce_int(g("moe_tp")),
         moe_ep=_coerce_int(g("moe_ep")),
         num_workers=_coerce_int(g("workers")),
+        batch_size=_coerce_int(g("bs")),
         memory_gb=_coerce_float(g("memory")),
         gemm=g("gemm"),
         kvcache=g("kvcache"),
@@ -409,10 +414,20 @@ def _row_to_config(row: pd.Series, req: RecommendRequest) -> RecommendConfig:
         cfg.prefill_config = _worker_config_from_row(row, "p", req)
         cfg.decode_config = _worker_config_from_row(row, "d", req)
         if cfg.memory is None:
-            p_mem = _coerce_float(row.get("(p)memory"))
-            d_mem = _coerce_float(row.get("(d)memory"))
-            if p_mem is not None or d_mem is not None:
-                cfg.memory = (p_mem or 0.0) + (d_mem or 0.0)
+            # (p)/(d)/(e)memory are each per-GPU peak usage (GB) for that worker
+            # type — each is checked against a single GPU's capacity, so they are
+            # NOT additive. The meaningful single figure is the worst-case
+            # per-GPU across all pools (prefill, decode, and encode).
+            phase_mems = [
+                m for m in (
+                    _coerce_float(row.get("(p)memory")),
+                    _coerce_float(row.get("(d)memory")),
+                    _coerce_float(row.get("(e)memory")),
+                )
+                if m is not None
+            ]
+            if phase_mems:
+                cfg.memory = max(phase_mems)
 
     return cfg
 

--- a/services/aiconfigurator/tools/api_service/app.py
+++ b/services/aiconfigurator/tools/api_service/app.py
@@ -103,6 +103,23 @@ class EstimateRequest(BaseModel):
     moe_tp_size: int | None = Field(default=None)
     moe_ep_size: int | None = Field(default=None)
     attention_dp_size: int = Field(default=1)
+    # Serving mode. When 'disagg', the prefill_*/decode_* fields below drive
+    # separate prefill and decode pools; the top-level tp/pp/batch fields act
+    # as fallbacks for any per-role field left unset.
+    mode: str = Field(default="agg", description="Serving mode: 'agg' or 'disagg'.")
+    decode_system: str | None = Field(default=None, description="GPU system for disagg decode workers; defaults to `system`.")
+    prefill_tp_size: int | None = Field(default=None)
+    prefill_pp_size: int | None = Field(default=None)
+    prefill_moe_tp_size: int | None = Field(default=None)
+    prefill_moe_ep_size: int | None = Field(default=None)
+    prefill_batch_size: int | None = Field(default=None)
+    prefill_num_workers: int | None = Field(default=None)
+    decode_tp_size: int | None = Field(default=None)
+    decode_pp_size: int | None = Field(default=None)
+    decode_moe_tp_size: int | None = Field(default=None)
+    decode_moe_ep_size: int | None = Field(default=None)
+    decode_batch_size: int | None = Field(default=None)
+    decode_num_workers: int | None = Field(default=None)
     inclusive_tpot: bool = Field(
         default=False,
         description="Report TPOT as (ttft + tpot * (osl - 1)) / osl, spreading TTFT across all output tokens. "
@@ -223,6 +240,10 @@ class EstimateResponse(BaseModel):
     power_w: float | None = None
     serving_config: ServingConfig | None = None
     memory_breakdown: MemoryBreakdown | None = None
+    # Serving mode + disagg detail (present when mode='disagg')
+    mode: str = "agg"
+    prefill_config: WorkerConfig | None = None
+    decode_config: WorkerConfig | None = None
 
 
 class MemoryRequest(BaseModel):
@@ -663,26 +684,70 @@ def post_estimate(
     Use this when you know your deployment configuration and want to predict
     its performance. Use /recommend when you want to find the optimal config.
     """
+    is_disagg = req.mode == "disagg"
+
+    # Resolve per-role parallelism, falling back to the top-level agg fields.
+    p_tp = req.prefill_tp_size or req.tp_size
+    p_pp = req.prefill_pp_size or req.pp_size
+    p_bs = req.prefill_batch_size or req.batch_size
+    p_workers = req.prefill_num_workers or 1
+    p_moe_tp = req.prefill_moe_tp_size or req.moe_tp_size
+    p_moe_ep = req.prefill_moe_ep_size or req.moe_ep_size
+    d_tp = req.decode_tp_size or req.tp_size
+    d_pp = req.decode_pp_size or req.pp_size
+    d_bs = req.decode_batch_size or req.batch_size
+    d_workers = req.decode_num_workers or 1
+    d_moe_tp = req.decode_moe_tp_size or req.moe_tp_size
+    d_moe_ep = req.decode_moe_ep_size or req.moe_ep_size
+
     try:
         with _with_model_config(req.model_path, req.model_config_data) as effective_path:
-            result = cli_estimate(
-                effective_path,
-                system_name=req.system,
-                backend_name=req.backend,
-                backend_version=req.backend_version,
-                database_mode=req.database_mode,
-                isl=req.isl,
-                osl=req.osl,
-                batch_size=req.batch_size,
-                tp_size=req.tp_size,
-                pp_size=req.pp_size,
-                attention_dp_size=req.attention_dp_size,
-                moe_tp_size=req.moe_tp_size,
-                moe_ep_size=req.moe_ep_size,
-                gemm_quant_mode=req.gemm_quant_mode,
-                kvcache_quant_mode=req.kvcache_quant_mode,
-                fmha_quant_mode=req.fmha_quant_mode,
-            )
+            if is_disagg:
+                result = cli_estimate(
+                    effective_path,
+                    system_name=req.system,
+                    decode_system_name=req.decode_system,
+                    backend_name=req.backend,
+                    backend_version=req.backend_version,
+                    database_mode=req.database_mode,
+                    mode="disagg",
+                    isl=req.isl,
+                    osl=req.osl,
+                    prefill_tp_size=p_tp,
+                    prefill_pp_size=p_pp,
+                    prefill_moe_tp_size=p_moe_tp,
+                    prefill_moe_ep_size=p_moe_ep,
+                    prefill_batch_size=p_bs,
+                    prefill_num_workers=p_workers,
+                    decode_tp_size=d_tp,
+                    decode_pp_size=d_pp,
+                    decode_moe_tp_size=d_moe_tp,
+                    decode_moe_ep_size=d_moe_ep,
+                    decode_batch_size=d_bs,
+                    decode_num_workers=d_workers,
+                    gemm_quant_mode=req.gemm_quant_mode,
+                    kvcache_quant_mode=req.kvcache_quant_mode,
+                    fmha_quant_mode=req.fmha_quant_mode,
+                )
+            else:
+                result = cli_estimate(
+                    effective_path,
+                    system_name=req.system,
+                    backend_name=req.backend,
+                    backend_version=req.backend_version,
+                    database_mode=req.database_mode,
+                    isl=req.isl,
+                    osl=req.osl,
+                    batch_size=req.batch_size,
+                    tp_size=req.tp_size,
+                    pp_size=req.pp_size,
+                    attention_dp_size=req.attention_dp_size,
+                    moe_tp_size=req.moe_tp_size,
+                    moe_ep_size=req.moe_ep_size,
+                    gemm_quant_mode=req.gemm_quant_mode,
+                    kvcache_quant_mode=req.kvcache_quant_mode,
+                    fmha_quant_mode=req.fmha_quant_mode,
+                )
     except (ValueError, AttributeError, Exception) as e:
         _common_error_handler(e, "estimate", req.model_path, req.backend, req.system)
 
@@ -702,16 +767,52 @@ def post_estimate(
         tokens_per_second_per_user=_coerce_float(raw.get("tokens/s/user")),
         memory=_coerce_float(raw.get("memory")),
         concurrency=_coerce_int(raw.get("bs")),
-        tp=_coerce_int(raw.get("tp")) or req.tp_size,
-        pp=_coerce_int(raw.get("pp")) or req.pp_size,
-        dp=_coerce_int(raw.get("dp")),
+        tp=None if is_disagg else (_coerce_int(raw.get("tp")) or req.tp_size),
+        pp=None if is_disagg else (_coerce_int(raw.get("pp")) or req.pp_size),
+        dp=None if is_disagg else _coerce_int(raw.get("dp")),
         system=raw.get("system", req.system),
         backend=raw.get("backend", req.backend),
         backend_version=raw.get("version", req.backend_version),
         gemm=raw.get("gemm"),
         kvcache=raw.get("kvcache"),
         power_w=result.power_w,
+        mode=req.mode,
     )
+
+    if is_disagg:
+        # (p)/(d)memory are per-GPU peaks; the single figure is the worst case.
+        p_mem = _coerce_float(raw.get("(p)memory"))
+        d_mem = _coerce_float(raw.get("(d)memory"))
+        phase_mems = [m for m in (p_mem, d_mem) if m is not None]
+        if phase_mems:
+            resp.memory = max(phase_mems)
+
+        gemm_q = req.gemm_quant_mode if req.gemm_quant_mode and req.gemm_quant_mode != "half" else None
+        kv_q = req.kvcache_quant_mode if req.kvcache_quant_mode and req.kvcache_quant_mode != "half" else None
+        want_memory = "memory" in includes
+
+        resp.prefill_config = WorkerConfig(
+            tp=p_tp, pp=p_pp, moe_tp=p_moe_tp, moe_ep=p_moe_ep,
+            num_workers=p_workers, batch_size=p_bs, memory_gb=p_mem,
+            backend_version=resp.backend_version,
+        )
+        resp.decode_config = WorkerConfig(
+            tp=d_tp, pp=d_pp, moe_tp=d_moe_tp, moe_ep=d_moe_ep,
+            num_workers=d_workers, batch_size=d_bs, memory_gb=d_mem,
+            backend_version=resp.backend_version,
+        )
+
+        if want_memory:
+            with _with_model_config(req.model_path, req.model_config_data) as effective_path:
+                for worker in (resp.prefill_config, resp.decode_config):
+                    if worker and worker.tp:
+                        worker.memory_breakdown = _build_memory_breakdown(
+                            effective_path, req.system, req.backend, req.backend_version,
+                            worker.tp, worker.pp or 1, req.isl, req.osl,
+                            worker.batch_size or req.batch_size,
+                            gemm_q, kv_q, worker.moe_tp, worker.moe_ep,
+                        )
+        return resp
 
     if "config" in includes:
         resp.serving_config = _build_serving_config(

--- a/services/aiconfigurator/tools/api_service/app.py
+++ b/services/aiconfigurator/tools/api_service/app.py
@@ -14,7 +14,7 @@ import logging
 import sys
 import tempfile
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 import pandas as pd
 import uvicorn
@@ -106,7 +106,7 @@ class EstimateRequest(BaseModel):
     # Serving mode. When 'disagg', the prefill_*/decode_* fields below drive
     # separate prefill and decode pools; the top-level tp/pp/batch fields act
     # as fallbacks for any per-role field left unset.
-    mode: str = Field(default="agg", description="Serving mode: 'agg' or 'disagg'.")
+    mode: Literal["agg", "disagg"] = Field(default="agg", description="Serving mode: 'agg' or 'disagg'.")
     decode_system: str | None = Field(default=None, description="GPU system for disagg decode workers; defaults to `system`.")
     prefill_tp_size: int | None = Field(default=None)
     prefill_pp_size: int | None = Field(default=None)
@@ -803,11 +803,16 @@ def post_estimate(
         )
 
         if want_memory:
+            # The decode pool may run on a different GPU system than prefill.
+            decode_sys = req.decode_system or req.system
             with _with_model_config(req.model_path, req.model_config_data) as effective_path:
-                for worker in (resp.prefill_config, resp.decode_config):
+                for worker, worker_sys in (
+                    (resp.prefill_config, req.system),
+                    (resp.decode_config, decode_sys),
+                ):
                     if worker and worker.tp:
                         worker.memory_breakdown = _build_memory_breakdown(
-                            effective_path, req.system, req.backend, req.backend_version,
+                            effective_path, worker_sys, req.backend, req.backend_version,
                             worker.tp, worker.pp or 1, req.isl, req.osl,
                             worker.batch_size or req.batch_size,
                             gemm_q, kv_q, worker.moe_tp, worker.moe_ep,


### PR DESCRIPTION
## What

Adds disaggregated serving support across the **Recommend**, **KV-cache**, and **Performance** tools. Previously all three modeled a single homogeneous GPU pool (agg); real deployments increasingly split **prefill** and **decode** onto separate, independently-scaled pools (xPyD). The AIConfigurator gateway already computes disagg — the frontend was discarding it.

Along the way this also surfaces outputs that were missing even for agg: **workers**, **expert parallelism (EP/ETP)**, **context parallel (CP)**, and **batch size**.

## Changes by page

**Recommend** (`lib/api/recommend.ts`, `app/recommend/AdvancedEstimate.tsx`)
- Parses `chosen_mode` + `prefill_config`/`decode_config`; renders per-phase Prefill/Decode/Encode tiles with an agg/disagg badge.
- `gpusPerWorker = tp·pp·dp·cp` (matches the SDK's `WORKER_GPU_DIMS`) — fixes two prior bugs: `cp` was dropped and MoE wrongly used `etp·ep·pp` (expert dims don't add GPUs). EP/ETP are labels only.
- Explicit, self-consistent xPyD math on the tile back faces.
- **Memory scope fix**: the gateway's memory is per-GPU peak; the backend was summing prefill+decode (meaningless) and dropping encode. Now takes the worst-case `max`; tile relabeled "Peak mem / GPU" (no more double-divide). Removed the vestigial always-`unspecified` `scope` field.
- **Concurrency/throughput fix**: the gateway reports these per replica. Headline now scales to cluster totals (also corrects multi-replica **agg**). Monthly cost now uses the aggregate GPU total, not gpus-per-worker.

**KV-cache** (`app/kv-cache/KvCacheCalc.tsx`)
- Agg/disagg toggle; disagg fans out one `/api/memory` call per pool (`Promise.all`) and renders a full result section per pool. No backend change (`/memory` already takes per-pool dims).

**Performance** (`app/performance/PerformanceEstimate.tsx`, `lib/api/estimate-adapter.ts`)
- Serving-mode toggle + per-pool inputs; runs the SDK's `cli_estimate` in `mode='disagg'`.
- GPU count = Σ `workers × gpus/worker`; the tile grid swaps Weight/KV tiles for Prefill/Decode pool tiles; agg-only deep-dive cards hidden in disagg; CLI-copy emits one `vllm serve` per pool with a KV-connector note.

**Backend** (`services/aiconfigurator/`)
- `WorkerConfig` gains `cp` + `batch_size`; disagg recommend memory is `max` across prefill/decode/**encode** (not summed).
- `/estimate` gains `mode` + `prefill_*`/`decode_*` params and returns `prefill_config`/`decode_config` (SDK's `cli_estimate` already supported `mode='disagg'`).
- Unit tests added/updated (`test_api_service.py`).

## Encode (follow-up, not in this PR)
The UI renders an encode phase **if present**, but a dedicated encode pool (E+P+D) isn't producible via `cli_recommend` today — only `cli_default` has `enable_epd`. Surfacing encode is a tracked upstream change to `aiconfigurator` (`enable_epd` on `cli_recommend`) + dropping the `(e)`-column skip in our wrapper. UI is ready for it.

## Known limitations
- Save/Export on Performance are gated to agg-only (saved-estimate schema is agg-shaped).
- Heterogeneous decode-GPU pricing isn't modeled (no per-pool GPU selector yet; same-GPU cost is correct).

## Testing
- `npm run type-check`, `npm run lint`, `npm run build` all green.
- Python unit tests run in CI (the `aiconfigurator-core` wheel is Linux-x86_64 only; can't execute on macOS/arm64). Disagg GPU math hand-verified against a sample: `16 = (4×1 + 1×4) × 2`.
- Live gateway smoke test on each page still recommended before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added aggregated and disaggregated serving modes for KV-cache, performance, and recommendation estimates.
  - Configure independent Prefill and Decode pools with separate parallelism, batching, worker, and MoE settings.
  - Added per-pool result cards, phase-specific metrics, GPU totals, memory usage, throughput, and deployment guidance.
  - Recommendation views now show phase layouts, replica topology, deployment totals, and monthly costs.
  - CLI output provides separate commands and KV-transfer guidance for disaggregated deployments.

- **Tests**
  - Expanded coverage for disaggregated estimate requests, configurations, and memory reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->