### PR TITLE
Fixing GPU Family dropdown names

### DIFF
--- a/services/aiconfigurator/tests/unit/tools/test_api_service.py
+++ b/services/aiconfigurator/tests/unit/tools/test_api_service.py
@@ -613,8 +613,13 @@ class TestIntegration:
     @classmethod
     def setup_class(cls):
         from configiq.systems import load_device_names_from_perf_data
+
         import tools.api_service.app as _app_mod
-        _app_mod._DEVICE_DISPLAY_NAMES = load_device_names_from_perf_data()
+        device_names = load_device_names_from_perf_data()
+        if not device_names:
+            pytest.skip("device display names unavailable")
+        _app_mod._DEVICE_DISPLAY_NAMES = device_names
+        _app_mod._DEVICE_NAMES_LOADED = True
 
     def test_recommend_real(self):
         resp = client.post("/recommend", json={

--- a/services/aiconfigurator/tests/unit/tools/test_api_service.py
+++ b/services/aiconfigurator/tests/unit/tools/test_api_service.py
@@ -497,6 +497,7 @@ class TestModels:
 
 class TestSystems:
 
+    @patch.dict("tools.api_service.app._DEVICE_DISPLAY_NAMES", {"h200_sxm": "NVIDIA H200 SXM", "a100_sxm": "NVIDIA A100-SXM4-80GB"})
     @patch("tools.api_service.app.supported_systems", lambda: {"h200_sxm", "a100_sxm"})
     def test_returns_sorted_objects(self):
         resp = client.get("/systems")
@@ -524,6 +525,7 @@ class TestSystems:
         assert sys["tdp_watts"] == 700.0
         assert sys["gpus_per_node"] == 8
 
+    @patch.dict("tools.api_service.app._DEVICE_DISPLAY_NAMES", {"h200_sxm": "NVIDIA H200 SXM"})
     @patch("tools.api_service.app.load_system_spec")
     @patch("tools.api_service.app.supported_systems", lambda: {"h200_sxm"})
     def test_include_specs_bandwidth_and_tflops(self, mock_spec):
@@ -533,6 +535,7 @@ class TestSystems:
         assert sys["memory_bandwidth_bytes"] == 4800000000000
         assert abs(sys["bf16_tflops"] - 989.0) < 0.1
 
+    @patch.dict("tools.api_service.app._DEVICE_DISPLAY_NAMES", {"h200_sxm": "NVIDIA H200 SXM"})
     @patch("tools.api_service.app.supported_systems", lambda: {"h200_sxm"})
     def test_no_include_omits_specs(self):
         resp = client.get("/systems")
@@ -540,6 +543,7 @@ class TestSystems:
         assert "vendor" not in sys
         assert "memory_bytes" not in sys
 
+    @patch.dict("tools.api_service.app._DEVICE_DISPLAY_NAMES", {"h200_sxm": "NVIDIA H200 SXM"})
     @patch("tools.api_service.app.load_system_spec")
     @patch("tools.api_service.app.supported_systems", lambda: {"h200_sxm"})
     def test_spec_failure_still_returns_entry(self, mock_spec):
@@ -605,6 +609,12 @@ def _skip_if_missing_perf_data(resp) -> None:
     reason="aiconfigurator SDK not installed or missing perf data",
 )
 class TestIntegration:
+
+    @classmethod
+    def setup_class(cls):
+        from configiq.systems import load_device_names_from_perf_data
+        import tools.api_service.app as _app_mod
+        _app_mod._DEVICE_DISPLAY_NAMES = load_device_names_from_perf_data()
 
     def test_recommend_real(self):
         resp = client.post("/recommend", json={

--- a/services/aiconfigurator/tools/api_service/app.py
+++ b/services/aiconfigurator/tools/api_service/app.py
@@ -932,9 +932,12 @@ def get_systems(
 
     systems = []
     for sys_id in sorted(supported_systems()):
+        device_name = _DEVICE_DISPLAY_NAMES.get(sys_id)
+        if device_name is None:
+            continue
         entry: dict[str, Any] = {
             "id": sys_id,
-            "name": _DEVICE_DISPLAY_NAMES.get(sys_id, sys_id),
+            "name": device_name,
         }
         if want_specs:
             try:

--- a/services/aiconfigurator/tools/api_service/app.py
+++ b/services/aiconfigurator/tools/api_service/app.py
@@ -555,6 +555,7 @@ def _architecture_from_sm(sm_version: int) -> str:
 # aiconfigurator SDK (via configiq.systems). aicostings loads the same map from
 # the same source so the two services never drift on GPU naming.
 _DEVICE_DISPLAY_NAMES: dict[str, str] = {}
+_DEVICE_NAMES_LOADED: bool = False
 
 
 def _parse_include(include: str | None) -> set[str]:
@@ -596,8 +597,9 @@ else:
 @app.on_event("startup")
 def startup_event():
     """Load GPU display names from the aiconfigurator SDK at startup."""
-    global _DEVICE_DISPLAY_NAMES
+    global _DEVICE_DISPLAY_NAMES, _DEVICE_NAMES_LOADED
     _DEVICE_DISPLAY_NAMES = load_device_names_from_perf_data()
+    _DEVICE_NAMES_LOADED = bool(_DEVICE_DISPLAY_NAMES)
 
 
 @app.post("/recommend")
@@ -934,7 +936,9 @@ def get_systems(
     for sys_id in sorted(supported_systems()):
         device_name = _DEVICE_DISPLAY_NAMES.get(sys_id)
         if device_name is None:
-            continue
+            if _DEVICE_NAMES_LOADED:
+                continue
+            device_name = sys_id
         entry: dict[str, Any] = {
             "id": sys_id,
             "name": device_name,

--- a/services/aiconfigurator/tools/api_service/app.py
+++ b/services/aiconfigurator/tools/api_service/app.py
@@ -320,6 +320,7 @@ _SM_ARCHITECTURE = {
     89: "ada-lovelace",
     90: "hopper",
     100: "blackwell",
+    103: "blackwell",
     120: "blackwell",
 }
 
@@ -544,7 +545,10 @@ def _common_error_handler(e: Exception, op: str, model_path: str, backend: str, 
 
 
 def _architecture_from_sm(sm_version: int) -> str:
-    return _SM_ARCHITECTURE.get(sm_version, f"sm_{sm_version}")
+    sm_arch = _SM_ARCHITECTURE.get(sm_version, f"sm_{sm_version}")
+    if sm_arch == f"sm_{sm_version}":
+        return "Other"
+    return sm_arch
 
 
 # Cache of system_id -> vendor device name, populated at startup from the
@@ -938,9 +942,14 @@ def get_systems(
                 gpu = spec.get("gpu", {})
                 node = spec.get("node", {})
                 sm = int(gpu.get("sm_version", 0))
+                sm_arch = _architecture_from_sm(sm)
+                if sm_arch == "Other":
+                    vendor_name = ""
+                else:
+                    vendor_name = "nvidia"
                 entry.update({
-                    "vendor": "nvidia",
-                    "architecture": _architecture_from_sm(sm),
+                    "vendor": vendor_name,
+                    "architecture": sm_arch,
                     "memory_bytes": int(gpu.get("mem_capacity", 0)),
                     "memory_bandwidth_bytes": int(gpu.get("mem_bw", 0)),
                     "bf16_tflops": float(gpu.get("bfloat16_tc_flops", 0)) / 1e12,


### PR DESCRIPTION
Fixes a bug where certain GPUs have their family listed as Sm_0 or Sm_103. Resolved by relegating id 103 as Blackwell and relegating any ids not in our mapping dictionary as "Other" 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for identifying compute capability 103 as the Blackwell architecture.
  * Unknown GPU architectures are now labeled as “Other.”

* **Bug Fixes**
  * Corrected system metadata so unknown architectures report an empty vendor.
  * System listings now retain all supported systems and use system IDs when display names are unavailable, improving visibility when device-name information cannot be loaded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->